### PR TITLE
Skipped processing oppfølgingstilfelle not relevant for aktivitetskrav

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
@@ -95,8 +95,8 @@ fun AktivitetskravVurdering.toKafkaAktivitetskravVurdering() = KafkaAktivitetskr
     updatedBy = this.updatedBy,
 )
 
-fun AktivitetskravVurdering.gjelderOppfolgingstilfelle(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean =
-    this.stoppunktAt.isAfter(oppfolgingstilfelle.tilfelleStart) && oppfolgingstilfelle.tilfelleEnd.isAfter(
+infix fun AktivitetskravVurdering.gjelder(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean =
+    this.personIdent == oppfolgingstilfelle.personIdent && this.stoppunktAt.isAfter(oppfolgingstilfelle.tilfelleStart) && oppfolgingstilfelle.tilfelleEnd.isAfter(
         stoppunktAt
     )
 

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVurderingSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVurderingSpek.kt
@@ -1,0 +1,54 @@
+package no.nav.syfo.aktivitetskrav
+
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
+import no.nav.syfo.aktivitetskrav.domain.gjelder
+import no.nav.syfo.oppfolgingstilfelle.kafka.toLatestOppfolgingstilfelle
+import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.testhelper.UserConstants.OTHER_ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.testhelper.generator.createKafkaOppfolgingstilfellePerson
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+
+private val sevenWeeksAgo = LocalDate.now().minusWeeks(7)
+private val nineWeeksAgo = LocalDate.now().minusWeeks(9)
+
+class AktivitetskravVurderingSpek : Spek({
+    val oppfolgingstilfelle = createKafkaOppfolgingstilfellePerson(
+        personIdent = ARBEIDSTAKER_PERSONIDENT,
+        tilfelleStart = nineWeeksAgo,
+        tilfelleEnd = LocalDate.now(),
+        false,
+    ).toLatestOppfolgingstilfelle()
+
+    describe("gjelder Oppfolgingstilfelle") {
+        it("returns false when different arbeidstakere") {
+            val aktivitetskravVurdering =
+                AktivitetskravVurdering.ny(
+                    personIdent = OTHER_ARBEIDSTAKER_PERSONIDENT,
+                    tilfelleStart = nineWeeksAgo
+                )
+
+            aktivitetskravVurdering gjelder oppfolgingstilfelle!! shouldBeEqualTo false
+        }
+        it("returns true when equal arbeidstaker and stoppunkt between tilfelle start and end") {
+            val aktivitetskravVurdering =
+                AktivitetskravVurdering.ny(
+                    personIdent = ARBEIDSTAKER_PERSONIDENT,
+                    tilfelleStart = nineWeeksAgo
+                )
+
+            aktivitetskravVurdering gjelder oppfolgingstilfelle!! shouldBeEqualTo true
+        }
+        it("returns false when equal arbeidstaker and stoppunkt after tilfelle end") {
+            val aktivitetskravVurdering =
+                AktivitetskravVurdering.ny(
+                    personIdent = ARBEIDSTAKER_PERSONIDENT,
+                    tilfelleStart = sevenWeeksAgo
+                )
+
+            aktivitetskravVurdering gjelder oppfolgingstilfelle!! shouldBeEqualTo false
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -9,5 +9,6 @@ object UserConstants {
     private const val VIRKSOMHETSNUMMER = "123456789"
 
     val ARBEIDSTAKER_PERSONIDENT = PersonIdent(ARBEIDSTAKER_FNR)
+    val OTHER_ARBEIDSTAKER_PERSONIDENT = PersonIdent(ARBEIDSTAKER_PERSONIDENT.value.replace("2", "1"))
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer(VIRKSOMHETSNUMMER)
 }


### PR DESCRIPTION
Dropper (foreløpig) å håndterere caser hvor oppfølgingstilfellet har gått fra å være lenger enn 8 uker til kortere enn 8 uker. Tanken er at det vil være såpass få tilfeller at veileder kan håndtere disse oppgavene ved å sette Oppfylt.