### PR TITLE
Veileder-api: Update aktivitetskrav-vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -1,17 +1,22 @@
 package no.nav.syfo.aktivitetskrav.api
 
+import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.aktivitetskrav.AktivitetskravVurderingService
 import no.nav.syfo.aktivitetskrav.domain.toResponseDTOList
 import no.nav.syfo.application.api.VeilederTilgangskontrollPlugin
 import no.nav.syfo.client.veiledertilgang.VeilederTilgangskontrollClient
-import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
-import no.nav.syfo.util.getPersonIdent
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.util.*
+import java.util.UUID
 
 const val aktivitetskravApiBasePath = "/api/internad/v1/aktivitetskrav"
 const val aktivitetskravApiPersonidentPath = "/personident"
+const val aktivitetskravVurderingParam = "aktivitetskravVurderingUuid"
+const val vurderAktivitetskravPath = "/vurder"
 
 private const val apiAction = "access aktivitetskrav for person"
 
@@ -25,13 +30,36 @@ fun Route.registerAktivitetskravApi(
             this.veilederTilgangskontrollClient = veilederTilgangskontrollClient
         }
         get(aktivitetskravApiPersonidentPath) {
-            val personIdent = call.getPersonIdent()
-                ?: throw IllegalArgumentException("Failed to $apiAction: No $NAV_PERSONIDENT_HEADER supplied in request header")
+            val personIdent = call.personIdent()
             val responseDTOList = aktivitetskravVurderingService.getAktivitetskravVurderinger(
                 personIdent = personIdent,
             ).toResponseDTOList()
 
             call.respond(responseDTOList)
         }
+        post("/{$aktivitetskravVurderingParam}$vurderAktivitetskravPath") {
+            val personIdent = call.personIdent()
+            val vurderingUUID = UUID.fromString(call.parameters[aktivitetskravVurderingParam])
+            val requestDTO = call.receive<AktivitetskravVurderingRequestDTO>()
+
+            val vurderingToUpdate =
+                aktivitetskravVurderingService.getAktivitetskravVurdering(uuid = vurderingUUID)
+                    ?: throw IllegalArgumentException("Failed to vurdere aktivitetskrav: vurdering not found")
+
+            if (vurderingToUpdate.personIdent != personIdent) {
+                throw IllegalArgumentException("Failed to vurdere aktivitetskrav: personIdent on vurdering differs from request")
+            }
+
+            aktivitetskravVurderingService.vurderAktivitetskrav(
+                aktivitetskravVurdering = vurderingToUpdate,
+                aktivitetskravVurderingRequestDTO = requestDTO,
+                veilederIdent = call.getNAVIdent(),
+            )
+
+            call.respond(HttpStatusCode.OK)
+        }
     }
 }
+
+private fun ApplicationCall.personIdent(): PersonIdent = this.getPersonIdent()
+    ?: throw IllegalArgumentException("Failed to $apiAction: No $NAV_PERSONIDENT_HEADER supplied in request header")

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravVurderingRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravVurderingRequestDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.aktivitetskrav.api
+
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurderingStatus
+
+data class AktivitetskravVurderingRequestDTO(
+    val status: AktivitetskravVurderingStatus,
+    val beskrivelse: String?,
+)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravVurderingResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravVurderingResponseDTO.kt
@@ -1,12 +1,13 @@
 package no.nav.syfo.aktivitetskrav.api
 
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurderingStatus
 import java.time.LocalDateTime
 
 data class AktivitetskravVurderingResponseDTO(
     val uuid: String,
     val createdAt: LocalDateTime,
-    val updatedAt: LocalDateTime,
-    val status: String,
+    val sistEndret: LocalDateTime,
+    val status: AktivitetskravVurderingStatus,
     val updatedBy: String?,
     val beskrivelse: String?,
 )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
@@ -26,7 +26,7 @@ data class AktivitetskravVurdering private constructor(
     val uuid: UUID,
     val personIdent: PersonIdent,
     val createdAt: OffsetDateTime,
-    val updatedAt: OffsetDateTime,
+    val sistEndret: OffsetDateTime,
     val status: AktivitetskravVurderingStatus,
     val stoppunktAt: LocalDate,
     val beskrivelse: String?,
@@ -37,7 +37,7 @@ data class AktivitetskravVurdering private constructor(
             uuid = pAktivitetskravVurdering.uuid,
             personIdent = pAktivitetskravVurdering.personIdent,
             createdAt = pAktivitetskravVurdering.createdAt,
-            updatedAt = pAktivitetskravVurdering.updatedAt,
+            sistEndret = pAktivitetskravVurdering.updatedAt,
             status = AktivitetskravVurderingStatus.valueOf(pAktivitetskravVurdering.status),
             stoppunktAt = pAktivitetskravVurdering.stoppunktAt,
             beskrivelse = pAktivitetskravVurdering.beskrivelse,
@@ -70,7 +70,7 @@ data class AktivitetskravVurdering private constructor(
             uuid = UUID.randomUUID(),
             personIdent = personIdent,
             createdAt = nowUTC(),
-            updatedAt = nowUTC(),
+            sistEndret = nowUTC(),
             status = status,
             stoppunktAt = stoppunktDato(tilfelleStart),
             beskrivelse = beskrivelse,
@@ -89,7 +89,7 @@ fun AktivitetskravVurdering.toKafkaAktivitetskravVurdering() = KafkaAktivitetskr
     uuid = this.uuid.toString(),
     personIdent = this.personIdent.value,
     createdAt = this.createdAt,
-    updatedAt = this.updatedAt,
+    updatedAt = this.sistEndret,
     status = this.status.name,
     beskrivelse = this.beskrivelse,
     stoppunktAt = this.stoppunktAt,
@@ -104,13 +104,25 @@ infix fun AktivitetskravVurdering.gjelder(oppfolgingstilfelle: Oppfolgingstilfel
 fun AktivitetskravVurdering.isNy(): Boolean = this.status == AktivitetskravVurderingStatus.NY
 fun AktivitetskravVurdering.isAutomatiskOppfylt(): Boolean =
     this.status == AktivitetskravVurderingStatus.AUTOMATISK_OPPFYLT
+
 fun List<AktivitetskravVurdering>.toResponseDTOList() = this.map {
     AktivitetskravVurderingResponseDTO(
         uuid = it.uuid.toString(),
         createdAt = it.createdAt.toLocalDateTime(),
-        updatedAt = it.updatedAt.toLocalDateTime(),
-        status = it.status.name,
+        sistEndret = it.sistEndret.toLocalDateTime(),
+        status = it.status,
         updatedBy = it.updatedBy,
         beskrivelse = it.beskrivelse,
     )
 }
+
+fun AktivitetskravVurdering.vurder(
+    status: AktivitetskravVurderingStatus,
+    vurdertAv: String,
+    beskrivelse: String?,
+): AktivitetskravVurdering = this.copy(
+    status = status,
+    beskrivelse = beskrivelse,
+    sistEndret = nowUTC(),
+    updatedBy = vurdertAv,
+)

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -18,5 +18,11 @@ fun ApplicationCall.getConsumerClientId(): String? =
         JWT.decode(it).claims[JWT_CLAIM_AZP]?.asString()
     }
 
+fun ApplicationCall.getNAVIdent(): String {
+    val token = getBearerHeader() ?: throw Error("No Authorization header supplied")
+    return JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString()
+        ?: throw Error("Missing NAVident in private claims")
+}
+
 fun ApplicationCall.getBearerHeader(): String? =
     this.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -4,24 +4,28 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.server.testing.*
-import io.mockk.mockk
+import io.mockk.*
 import no.nav.syfo.aktivitetskrav.database.createAktivitetskravVurdering
+import no.nav.syfo.aktivitetskrav.database.getAktivitetskravVurderinger
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurderingStatus
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
 import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVurdering
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.util.*
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBeEqualTo
-import org.apache.kafka.clients.producer.KafkaProducer
+import org.amshove.kluent.*
+import org.apache.kafka.clients.producer.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import java.util.concurrent.Future
 
 class AktivitetskravApiSpek : Spek({
     val objectMapper: ObjectMapper = configuredJacksonMapper()
     val urlAktivitetskravVurderingerPerson = "$aktivitetskravApiBasePath/$aktivitetskravApiPersonidentPath"
+
     val nyAktivitetskravVurdering = AktivitetskravVurdering.ny(
         personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
         tilfelleStart = LocalDate.now().minusWeeks(10),
@@ -55,6 +59,12 @@ class AktivitetskravApiSpek : Spek({
             )
 
             beforeEachTest {
+                clearMocks(kafkaProducer)
+                coEvery {
+                    kafkaProducer.send(any())
+                } returns mockk<Future<RecordMetadata>>(relaxed = true)
+            }
+            afterEachTest {
                 database.dropData()
             }
 
@@ -67,12 +77,13 @@ class AktivitetskravApiSpek : Spek({
                 }
             }
 
-            describe("Get aktivitetskrav-vurderinger for person") {
-                val validToken = generateJWT(
-                    audience = externalMockEnvironment.environment.azure.appClientId,
-                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
-                )
+            val validToken = generateJWT(
+                audience = externalMockEnvironment.environment.azure.appClientId,
+                issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                navIdent = UserConstants.VEILEDER_IDENT,
+            )
 
+            describe("Get aktivitetskrav-vurderinger for person") {
                 describe("Happy path") {
                     it("Returns aktivitetskrav-vurderinger for person") {
                         createAktivitetskravVurderinger(
@@ -94,19 +105,19 @@ class AktivitetskravApiSpek : Spek({
                             responseDTOList.size shouldBeEqualTo 2
 
                             val first = responseDTOList.first()
-                            first.status shouldBeEqualTo AktivitetskravVurderingStatus.NY.name
+                            first.status shouldBeEqualTo AktivitetskravVurderingStatus.NY
                             first.beskrivelse shouldBeEqualTo null
                             first.updatedBy shouldBeEqualTo null
                             first.createdAt shouldNotBeEqualTo null
-                            first.updatedAt shouldNotBeEqualTo null
+                            first.sistEndret shouldNotBeEqualTo null
                             first.uuid shouldNotBeEqualTo null
 
                             val last = responseDTOList.last()
-                            last.status shouldBeEqualTo AktivitetskravVurderingStatus.AUTOMATISK_OPPFYLT.name
+                            last.status shouldBeEqualTo AktivitetskravVurderingStatus.AUTOMATISK_OPPFYLT
                             last.beskrivelse shouldBeEqualTo "Gradert aktivitet"
                             last.updatedBy shouldBeEqualTo null
                             last.createdAt shouldNotBeEqualTo null
-                            last.updatedAt shouldNotBeEqualTo null
+                            last.sistEndret shouldNotBeEqualTo null
                             last.uuid shouldNotBeEqualTo null
                         }
                     }
@@ -150,6 +161,128 @@ class AktivitetskravApiSpek : Spek({
                                     NAV_PERSONIDENT_HEADER,
                                     UserConstants.ARBEIDSTAKER_PERSONIDENT.value.drop(1)
                                 )
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
+                }
+            }
+
+            describe("Vurder aktivitetskrav for person") {
+                beforeEachTest {
+                    createAktivitetskravVurderinger(
+                        nyAktivitetskravVurdering,
+                    )
+                }
+
+                val urlVurderAktivitetskrav =
+                    "$aktivitetskravApiBasePath/${nyAktivitetskravVurdering.uuid}$vurderAktivitetskravPath"
+
+                val requestDTO = AktivitetskravVurderingRequestDTO(
+                    status = AktivitetskravVurderingStatus.OPPFYLT,
+                    beskrivelse = "Aktivitetskravet er oppfylt",
+                )
+
+                describe("Happy path") {
+                    it("Updates AktivitetskravVurdering and produces to Kafka if request is succesful") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurderAktivitetskrav) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                                setBody(objectMapper.writeValueAsString(requestDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
+                            verify(exactly = 1) {
+                                kafkaProducer.send(capture(producerRecordSlot))
+                            }
+
+                            val latestAktivitetskravVurdering =
+                                database.getAktivitetskravVurderinger(personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                                    .first()
+                            latestAktivitetskravVurdering.status shouldBeEqualTo requestDTO.status.name
+                            latestAktivitetskravVurdering.beskrivelse shouldBeEqualTo requestDTO.beskrivelse
+                            latestAktivitetskravVurdering.updatedBy shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                            latestAktivitetskravVurdering.updatedAt shouldBeGreaterThan latestAktivitetskravVurdering.createdAt
+
+                            val kafkaAktivitetskravVurdering = producerRecordSlot.captured.value()
+                            kafkaAktivitetskravVurdering.personIdent shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
+                            kafkaAktivitetskravVurdering.status shouldBeEqualTo latestAktivitetskravVurdering.status
+                            kafkaAktivitetskravVurdering.beskrivelse shouldBeEqualTo latestAktivitetskravVurdering.beskrivelse
+                            kafkaAktivitetskravVurdering.updatedBy shouldBeEqualTo latestAktivitetskravVurdering.updatedBy
+                            kafkaAktivitetskravVurdering.updatedAt.truncatedTo(ChronoUnit.MILLIS) shouldBeEqualTo latestAktivitetskravVurdering.updatedAt.truncatedTo(
+                                ChronoUnit.MILLIS
+                            )
+                        }
+                    }
+                }
+                describe("Unhappy path") {
+                    it("Returns status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurderAktivitetskrav) {}
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+                    it("returns status Forbidden if denied access to person") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurderAktivitetskrav) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(
+                                    NAV_PERSONIDENT_HEADER,
+                                    UserConstants.PERSONIDENT_VEILEDER_NO_ACCESS.value
+                                )
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Forbidden
+                        }
+                    }
+                    it("should return status BadRequest if no $NAV_PERSONIDENT_HEADER is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurderAktivitetskrav) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
+                    it("should return status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurderAktivitetskrav) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(
+                                    NAV_PERSONIDENT_HEADER,
+                                    UserConstants.ARBEIDSTAKER_PERSONIDENT.value.drop(1)
+                                )
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
+                    it("should return status BadRequest if no vurdering exists for uuid-param") {
+                        val randomUuid = UUID.randomUUID().toString()
+
+                        with(
+                            handleRequest(HttpMethod.Post, "$aktivitetskravApiBasePath/${randomUuid}$vurderAktivitetskravPath") {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
+                                setBody(objectMapper.writeValueAsString(requestDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
+                    it("should return status BadRequest if $NAV_PERSONIDENT_HEADER differs from personIdent for vurdering") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurderAktivitetskrav) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, UserConstants.OTHER_ARBEIDSTAKER_PERSONIDENT.value)
+                                setBody(objectMapper.writeValueAsString(requestDTO))
                             }
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.BadRequest

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -13,4 +13,5 @@ object UserConstants {
     val PERSONIDENT_VEILEDER_NO_ACCESS = PersonIdent(ARBEIDSTAKER_PERSONIDENT.value.replace("3", "1"))
 
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer(VIRKSOMHETSNUMMER)
+    const val VEILEDER_IDENT = "Z999999"
 }


### PR DESCRIPTION
Oppdaterer status, beskrivelse, veileder-ident som endret og sistEndret-felt for en aktivitetskrav-vurdering med gitt uuid. Skal oppdatere vurderingen i databasen og ut på Kafka.