### PR TITLE
Lag nytt automatisk oppfylt aktivitetskrav hvis vurdert og gradert tilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -101,6 +101,9 @@ infix fun Aktivitetskrav.gjelder(oppfolgingstilfelle: Oppfolgingstilfelle): Bool
 fun Aktivitetskrav.isAutomatiskOppfylt(): Boolean =
     this.status == AktivitetskravStatus.AUTOMATISK_OPPFYLT
 
+fun Aktivitetskrav.isVurdert(): Boolean =
+    this.status != AktivitetskravStatus.AUTOMATISK_OPPFYLT && this.status != AktivitetskravStatus.NY
+
 fun List<Aktivitetskrav>.toResponseDTOList() = this.map {
     AktivitetskravResponseDTO(
         uuid = it.uuid.toString(),

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -94,6 +94,13 @@ class KafkaOppfolgingstilfellePersonService(
                     aktivitetskrav = latestOppfolgingstilfelle.toAktivitetskrav(),
                 )
                 COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
+            } else if (latestAktivitetskravForTilfelle.isVurdert() && latestOppfolgingstilfelle.isGradertAtTilfelleEnd()) {
+                log.info("Found vurdert aktivitetskrav and Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid} gradert - creating aktivitetskrav")
+                aktivitetskravService.createAktivitetskrav(
+                    connection = connection,
+                    aktivitetskrav = latestOppfolgingstilfelle.toAktivitetskrav(),
+                )
+                COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
             } else {
                 log.info("Updating aktivitetskrav for Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid}")
                 aktivitetskravService.updateAktivitetskrav(


### PR DESCRIPTION
Dersom en person har blitt vurdert, så blir gradert og så blir 100% sykmeldt igjen så bør personen komme inn igjen i lista til vurdering.

Koden bygger på https://github.com/navikt/isaktivitetskrav/pull/25.
