### PR TITLE
Automatisk oppfyll "ubehandlet" aktivitetskrav fra tidligere oppfølgingstilfelle når nytt oppfølgingstilfelle > 8 uker

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
@@ -55,7 +55,7 @@ const val queryCreateAktivitetskravVurdering =
     RETURNING id
     """
 
-fun Connection.createAktiviteskravVurdering(
+fun Connection.createAktivitetskravVurdering(
     aktivitetskravId: Int,
     aktivitetskravVurdering: AktivitetskravVurdering,
 ) {

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -51,7 +51,7 @@ data class Aktivitetskrav private constructor(
                 tilfelleStart = tilfelleStart,
             )
 
-        fun automatiskOppfyltGradert(
+        fun automatiskOppfylt(
             personIdent: PersonIdent,
             tilfelleStart: LocalDate,
         ): Aktivitetskrav = create(
@@ -102,6 +102,8 @@ infix fun Aktivitetskrav.gjelder(oppfolgingstilfelle: Oppfolgingstilfelle): Bool
 fun Aktivitetskrav.isAutomatiskOppfylt(): Boolean =
     this.status == AktivitetskravStatus.AUTOMATISK_OPPFYLT
 
+fun Aktivitetskrav.isNy(): Boolean = this.status == AktivitetskravStatus.NY
+
 fun Aktivitetskrav.isVurdert(): Boolean =
     this.status != AktivitetskravStatus.AUTOMATISK_OPPFYLT && this.status != AktivitetskravStatus.NY
 
@@ -116,7 +118,7 @@ fun List<Aktivitetskrav>.toResponseDTOList() = this.map {
     )
 }
 
-internal fun Aktivitetskrav.updateFrom(oppfolgingstilfelle: Oppfolgingstilfelle): Aktivitetskrav {
+internal fun Aktivitetskrav.updateStoppunkt(oppfolgingstilfelle: Oppfolgingstilfelle): Aktivitetskrav {
     val stoppunktDato = Aktivitetskrav.stoppunktDato(oppfolgingstilfelle.tilfelleStart)
     return this.copy(
         stoppunktAt = stoppunktDato,
@@ -129,5 +131,10 @@ internal fun Aktivitetskrav.vurder(
 ): Aktivitetskrav = this.copy(
     status = aktivitetskravVurdering.status,
     vurderinger = listOf(aktivitetskravVurdering) + this.vurderinger,
+    sistEndret = nowUTC(),
+)
+
+internal fun Aktivitetskrav.oppfyllAutomatisk(): Aktivitetskrav = this.copy(
+    status = AktivitetskravStatus.AUTOMATISK_OPPFYLT,
     sistEndret = nowUTC(),
 )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -24,7 +24,7 @@ fun Oppfolgingstilfelle.passererAktivitetskravStoppunkt(): Boolean =
 
 fun Oppfolgingstilfelle.toAktivitetskrav(): Aktivitetskrav {
     return if (isGradertAtTilfelleEnd()) {
-        Aktivitetskrav.automatiskOppfyltGradert(
+        Aktivitetskrav.automatiskOppfylt(
             personIdent = this.personIdent,
             tilfelleStart = this.tilfelleStart,
         )

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -75,6 +75,12 @@ class KafkaOppfolgingstilfellePersonService(
                 personIdent = latestOppfolgingstilfelle.personIdent,
             )
 
+        aktivitetskravForPerson.filter { it.isNy() && !(it gjelder latestOppfolgingstilfelle) }
+            .forEach { aktivitetskrav ->
+                log.info("Found aktivitetskrav NY for tidligere Oppfolgingstilfelle - oppfyll automatisk")
+                aktivitetskravService.oppfyllAutomatisk(connection = connection, aktivitetskrav = aktivitetskrav)
+            }
+
         val latestAktivitetskravForTilfelle =
             aktivitetskravForPerson.firstOrNull { it gjelder latestOppfolgingstilfelle }
 
@@ -102,7 +108,7 @@ class KafkaOppfolgingstilfellePersonService(
                 COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
             } else {
                 log.info("Updating aktivitetskrav for Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid}")
-                aktivitetskravService.updateAktivitetskrav(
+                aktivitetskravService.updateAktivitetskravStoppunkt(
                     connection = connection,
                     aktivitetskrav = latestAktivitetskravForTilfelle,
                     oppfolgingstilfelle = latestOppfolgingstilfelle,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -65,7 +65,7 @@ class AktivitetskravSpek : Spek({
                     sistEndret = OffsetDateTime.now().minusDays(1)
                 )
 
-            val updatedAktivitetskrav = aktivitetskrav.updateFrom(oppfolgingstilfelle = oppfolgingstilfelle)
+            val updatedAktivitetskrav = aktivitetskrav.updateStoppunkt(oppfolgingstilfelle = oppfolgingstilfelle)
 
             updatedAktivitetskrav.sistEndret shouldBeGreaterThan aktivitetskrav.sistEndret
             updatedAktivitetskrav.stoppunktAt shouldBeEqualTo nineWeeksAgo.plusWeeks(8)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -37,7 +37,7 @@ class AktivitetskravApiSpek : Spek({
     ).copy(
         createdAt = nowUTC().minusWeeks(2)
     )
-    val automatiskOppfyltAktivitetskrav = Aktivitetskrav.automatiskOppfyltGradert(
+    val automatiskOppfyltAktivitetskrav = Aktivitetskrav.automatiskOppfylt(
         personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
         tilfelleStart = LocalDate.now().minusYears(2),
     ).copy(

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -46,7 +46,7 @@ class IdenthendelseServiceSpek : Spek({
             describe("Aktivitetskrav eksisterer for person") {
                 val aktivitetskravNy = Aktivitetskrav.ny(inaktivIdent, LocalDate.now().minusDays(50))
                 val aktivitetskravAutomatiskOppfylt =
-                    Aktivitetskrav.automatiskOppfyltGradert(inaktivIdent, LocalDate.now().minusDays(400))
+                    Aktivitetskrav.automatiskOppfylt(inaktivIdent, LocalDate.now().minusDays(400))
                 beforeEachTest {
                     database.createAktivitetskrav(aktivitetskravNy, aktivitetskravAutomatiskOppfylt)
                 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.testhelper.generator
+
+import no.nav.syfo.aktivitetskrav.domain.*
+import no.nav.syfo.aktivitetskrav.domain.vurder
+import no.nav.syfo.testhelper.UserConstants
+
+fun createAktivitetskravOppfylt(nyAktivitetskrav: Aktivitetskrav): Aktivitetskrav {
+    val oppfyltVurdering = AktivitetskravVurdering.create(
+        status = AktivitetskravStatus.OPPFYLT,
+        createdBy = UserConstants.VEILEDER_IDENT,
+        beskrivelse = "Oppfylt",
+        arsaker = listOf(VurderingArsak.FRISKMELDT),
+    )
+    return nyAktivitetskrav.vurder(oppfyltVurdering)
+}
+
+fun createAktivitetskravAvvent(nyAktivitetskrav: Aktivitetskrav): Aktivitetskrav {
+    val avventVurdering = AktivitetskravVurdering.create(
+        status = AktivitetskravStatus.AVVENT,
+        createdBy = UserConstants.VEILEDER_IDENT,
+        beskrivelse = "Avvent",
+        arsaker = listOf(VurderingArsak.INFORMASJON_BEHANDLER, VurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER),
+    )
+    return nyAktivitetskrav.vurder(avventVurdering)
+}
+
+fun createAktivitetskravUnntak(nyAktivitetskrav: Aktivitetskrav): Aktivitetskrav {
+    val unntakVurdering = AktivitetskravVurdering.create(
+        status = AktivitetskravStatus.UNNTAK,
+        createdBy = UserConstants.VEILEDER_IDENT,
+        beskrivelse = "Unntak",
+        arsaker = listOf(VurderingArsak.SJOMENN_UTENRIKS),
+    )
+    return nyAktivitetskrav.vurder(unntakVurdering)
+}


### PR DESCRIPTION
Også gjort litt renaming av metoder (presisering, typos) + refaktorering av test.