### PR TITLE
Only return aktivitetskrav with stoppunkt after Arena cutoff

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -75,3 +75,5 @@ spec:
       value: "dev-fss.pdl.pdl-api"
     - name: PDL_URL
       value: "https://pdl-api.dev-fss-pub.nais.io/graphql"
+    - name: ARENA_CUTOFF
+      value: "2020-01-01"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -75,3 +75,5 @@ spec:
       value: "prod-fss.pdl.pdl-api"
     - name: PDL_URL
       value: "https://pdl-api.prod-fss-pub.nais.io/graphql"
+    - name: ARENA_CUTOFF
+      value: "2023-03-10"

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -56,6 +56,7 @@ fun main() {
             aktivitetskravService = AktivitetskravService(
                 aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
                 database = applicationDatabase,
+                arenaCutoff = environment.arenaCutoff,
             )
             apiModule(
                 applicationState = applicationState,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -7,11 +7,13 @@ import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
 import java.sql.Connection
+import java.time.LocalDate
 import java.util.*
 
 class AktivitetskravService(
     private val aktivitetskravVurderingProducer: AktivitetskravVurderingProducer,
     private val database: DatabaseInterface,
+    private val arenaCutoff: LocalDate,
 ) {
 
     internal fun createAktivitetskrav(
@@ -65,6 +67,14 @@ class AktivitetskravService(
         database.getAktivitetskrav(uuid = uuid)?.let { pAktivitetskrav ->
             withVurderinger(pAktivitetskrav = pAktivitetskrav)
         }
+
+    internal fun getAktivitetskravAfterCutoff(
+        personIdent: PersonIdent,
+        connection: Connection? = null,
+    ): List<Aktivitetskrav> =
+        database.getAktivitetskrav(personIdent = personIdent, connection = connection).map { pAktivitetskrav ->
+            withVurderinger(pAktivitetskrav = pAktivitetskrav)
+        }.filter { it.stoppunktAt.isAfter(arenaCutoff) }
 
     internal fun getAktivitetskrav(personIdent: PersonIdent, connection: Connection? = null): List<Aktivitetskrav> =
         database.getAktivitetskrav(personIdent = personIdent, connection = connection).map { pAktivitetskrav ->

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -31,7 +31,7 @@ fun Route.registerAktivitetskravApi(
         }
         get(aktivitetskravApiPersonidentPath) {
             val personIdent = call.personIdent()
-            val responseDTOList = aktivitetskravService.getAktivitetskrav(
+            val responseDTOList = aktivitetskravService.getAktivitetskravAfterCutoff(
                 personIdent = personIdent,
             ).toResponseDTOList()
 

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
@@ -136,11 +136,11 @@ fun DatabaseInterface.getAktivitetskrav(
     connection: Connection? = null,
 ): List<PAktivitetskrav> {
     return connection?.getAktivitetskrav(
-        personIdent = personIdent
+        personIdent = personIdent,
     )
         ?: this.connection.use {
             it.getAktivitetskrav(
-                personIdent = personIdent
+                personIdent = personIdent,
             )
         }
 }

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.ClientsEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
+import java.time.LocalDate
 
 const val NAIS_DATABASE_ENV_PREFIX = "NAIS_DATABASE_ISAKTIVITETSKRAV_ISAKTIVITETSKRAV_DB"
 
@@ -35,6 +36,7 @@ data class Environment(
     ),
     val kafkaOppfolgingstilfellePersonProcessingEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_OPPFOLGINGSTILFELLE_PERSON_PROCESSING_ENABLED").toBoolean(),
     val toggleKafkaConsumerIdenthendelseEnabled: Boolean = getEnvVar("TOGGLE_KAFKA_IDENTHENDELSE_CONSUMER_ENABLED").toBoolean(),
+    val arenaCutoff: LocalDate = LocalDate.parse(getEnvVar("ARENA_CUTOFF")),
     val clients: ClientsEnvironment = ClientsEnvironment(
         syfotilgangskontroll = ClientEnvironment(
             baseUrl = getEnvVar("SYFOTILGANGSKONTROLL_URL"),

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -37,6 +37,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
         val aktivitetskravService = AktivitetskravService(
             aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
             database = database,
+            arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
         )
         val kafkaOppfolgingstilfellePersonService = KafkaOppfolgingstilfellePersonService(
             database = database,

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -16,6 +16,7 @@ fun Application.testApiModule(
     val aktivitetskravService = AktivitetskravService(
         aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
         database = externalMockEnvironment.database,
+        arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
     )
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.application.kafka.KafkaEnvironment
 import no.nav.syfo.client.ClientEnvironment
 import no.nav.syfo.client.ClientsEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
+import java.time.LocalDate
 
 fun testEnvironment(
     azureOpenIdTokenEndpoint: String,
@@ -47,6 +48,7 @@ fun testEnvironment(
     ),
     kafkaOppfolgingstilfellePersonProcessingEnabled = true,
     toggleKafkaConsumerIdenthendelseEnabled = true,
+    arenaCutoff = LocalDate.now().minusDays(365),
 )
 
 fun testAppState() = ApplicationState(


### PR DESCRIPTION
Filter in service after query, queries shouldn't be slow anyway, because no one have a lot of aktivitetskrav. Assuming we're never interested in older aktivitetskrav.