### PR TITLE
Avvent is not vurdert

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -116,7 +116,11 @@ fun Aktivitetskrav.isAutomatiskOppfylt(): Boolean =
 fun Aktivitetskrav.isNy(): Boolean = this.status == AktivitetskravStatus.NY
 
 fun Aktivitetskrav.isVurdert(): Boolean =
-    this.status != AktivitetskravStatus.AUTOMATISK_OPPFYLT && this.status != AktivitetskravStatus.NY
+    this.status in EnumSet.of(
+        AktivitetskravStatus.UNNTAK,
+        AktivitetskravStatus.OPPFYLT,
+        AktivitetskravStatus.IKKE_OPPFYLT,
+    )
 
 fun List<Aktivitetskrav>.toResponseDTOList() = this.map {
     AktivitetskravResponseDTO(


### PR DESCRIPTION
Endret isVurdert-sjekken slik at aktivitetskrav med status AVVENT ikke blir automatisk oppfylt hvis oppfølgingstilfellet blir gradert. (Personer med aktivitetskrav med status AVVENT skal vises med "aktivt" aktivitetskrav i syfooversikt helt til det er gjort en vurdering)