### PR TITLE
Bugfix aktiviteskrav gjelder tilfelle

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -5,6 +5,7 @@ import no.nav.syfo.aktivitetskrav.database.PAktivitetskrav
 import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVurdering
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
+import no.nav.syfo.util.isAfterOrEqual
 import no.nav.syfo.util.nowUTC
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -106,7 +107,7 @@ fun Aktivitetskrav.toKafkaAktivitetskravVurdering(): KafkaAktivitetskravVurderin
 }
 
 infix fun Aktivitetskrav.gjelder(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean =
-    this.personIdent == oppfolgingstilfelle.personIdent && this.stoppunktAt.isAfter(oppfolgingstilfelle.tilfelleStart) && oppfolgingstilfelle.tilfelleEnd.isAfter(
+    this.personIdent == oppfolgingstilfelle.personIdent && this.stoppunktAt.isAfter(oppfolgingstilfelle.tilfelleStart) && oppfolgingstilfelle.tilfelleEnd.isAfterOrEqual(
         stoppunktAt
     )
 

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -10,3 +10,5 @@ fun nowUTC(): OffsetDateTime = OffsetDateTime.now(defaultZoneOffset)
 fun tomorrow(): LocalDate = LocalDate.now().plusDays(1)
 
 fun OffsetDateTime.millisekundOpplosning(): OffsetDateTime = this.truncatedTo(ChronoUnit.MILLIS)
+
+fun LocalDate.isAfterOrEqual(date: LocalDate) = !this.isBefore(date)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -35,7 +35,7 @@ class AktivitetskravSpek : Spek({
 
             aktivitetskrav gjelder oppfolgingstilfelle shouldBeEqualTo false
         }
-        it("returns true when equal arbeidstaker and stoppunkt between tilfelle start and end") {
+        it("returns true when equal arbeidstaker and stoppunkt after tilfelle start and before tilfelle end") {
             val aktivitetskrav = createAktivitetskravNy(tilfelleStart = nineWeeksAgo)
 
             aktivitetskrav gjelder oppfolgingstilfelle shouldBeEqualTo true
@@ -44,6 +44,11 @@ class AktivitetskravSpek : Spek({
             val aktivitetskrav = createAktivitetskravNy(tilfelleStart = sevenWeeksAgo)
 
             aktivitetskrav gjelder oppfolgingstilfelle shouldBeEqualTo false
+        }
+        it("returns true when equal arbeidstaker and stoppunkt after tilfelle start and equal to tilfelle end") {
+            val aktivitetskrav = createAktivitetskravNy(tilfelleStart = LocalDate.now().minusWeeks(8))
+
+            aktivitetskrav gjelder oppfolgingstilfelle shouldBeEqualTo true
         }
     }
 


### PR DESCRIPTION
Fikser sjekk på om aktivitetskrav gjelder tilfelle til å returnere `true` dersom `tilfelleEnd` (tom-dato) er lik stoppunkt.