### PR TITLE
Add referanseTilfelleBitUuid to aktivitetskrav

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -19,8 +19,12 @@ class AktivitetskravService(
     internal fun createAktivitetskrav(
         connection: Connection,
         aktivitetskrav: Aktivitetskrav,
+        referanseTilfelleBitUUID: UUID,
     ) {
-        connection.createAktivitetskrav(aktivitetskrav = aktivitetskrav)
+        connection.createAktivitetskrav(
+            aktivitetskrav = aktivitetskrav,
+            referanseTilfelleBitUUID = referanseTilfelleBitUUID
+        )
         aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
             aktivitetskrav = aktivitetskrav
         )
@@ -89,7 +93,10 @@ class AktivitetskravService(
             Aktivitetskrav.fromVurdering(personIdent = personIdent, vurdering = aktivitetskravVurdering)
 
         database.connection.use { connection ->
-            val aktivitetskravId = connection.createAktivitetskrav(aktivitetskrav = aktivitetskrav)
+            val aktivitetskravId = connection.createAktivitetskrav(
+                aktivitetskrav = aktivitetskrav,
+                referanseTilfelleBitUUID = null
+            )
             connection.createAktivitetskravVurdering(
                 aktivitetskravId = aktivitetskravId,
                 aktivitetskravVurdering = aktivitetskravVurdering

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
@@ -18,13 +18,15 @@ const val queryCreateAktivitetskrav =
         updated_at,
         personident,
         status,
-        stoppunkt_at
-    ) values (DEFAULT, ?, ?, ?, ?, ?, ?)
+        stoppunkt_at,
+        referanse_tilfelle_bit_uuid
+    ) values (DEFAULT, ?, ?, ?, ?, ?, ?, ?)
     RETURNING id
     """
 
 fun Connection.createAktivitetskrav(
     aktivitetskrav: Aktivitetskrav,
+    referanseTilfelleBitUUID: UUID?,
 ): Int {
     val idList = this.prepareStatement(queryCreateAktivitetskrav).use {
         it.setString(1, aktivitetskrav.uuid.toString())
@@ -33,6 +35,7 @@ fun Connection.createAktivitetskrav(
         it.setString(4, aktivitetskrav.personIdent.value)
         it.setString(5, aktivitetskrav.status.name)
         it.setDate(6, Date.valueOf(aktivitetskrav.stoppunktAt))
+        it.setString(7, referanseTilfelleBitUUID?.toString())
         it.executeQuery().toList { getInt("id") }
     }
 
@@ -201,6 +204,7 @@ private fun ResultSet.toPAktivitetskrav(): PAktivitetskrav = PAktivitetskrav(
     updatedAt = getObject("updated_at", OffsetDateTime::class.java),
     status = getString("status"),
     stoppunktAt = getDate("stoppunkt_at").toLocalDate(),
+    referanseTilfelleBitUuid = getString("referanse_tilfelle_bit_uuid")?.let { UUID.fromString(it) },
 )
 
 private fun ResultSet.toPAktivitetskravVurdering(): PAktivitetskravVurdering = PAktivitetskravVurdering(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/PAktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/PAktivitetskrav.kt
@@ -15,6 +15,7 @@ data class PAktivitetskrav(
     val updatedAt: OffsetDateTime,
     val status: String,
     val stoppunktAt: LocalDate,
+    val referanseTilfelleBitUuid: UUID?,
 )
 
 fun PAktivitetskrav.toAktivitetskrav(aktivitetskravVurderinger: List<AktivitetskravVurdering>) =

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -90,25 +90,16 @@ class KafkaOppfolgingstilfellePersonService(
         log.info("TRACE Oppfolgingstilfelle with UUID ${latestOppfolgingstilfelle.uuid} gradertAtTilfelleEnd: ${latestOppfolgingstilfelle.gradertAtTilfelleEnd}")
         if (latestAktivitetskravForTilfelle == null) {
             log.info("Found no aktivitetskrav for Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid} - creating aktivitetskrav")
-            aktivitetskravService.createAktivitetskrav(
-                connection = connection,
-                aktivitetskrav = latestOppfolgingstilfelle.toAktivitetskrav(),
-            )
+            createAktivitetskrav(connection = connection, oppfolgingstilfelle = latestOppfolgingstilfelle)
             COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
         } else {
             if (latestAktivitetskravForTilfelle.isAutomatiskOppfylt() && !latestOppfolgingstilfelle.isGradertAtTilfelleEnd()) {
                 log.info("Found aktivitetskrav AUTOMATISK_OPPFYLT but Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid} not gradert - creating aktivitetskrav")
-                aktivitetskravService.createAktivitetskrav(
-                    connection = connection,
-                    aktivitetskrav = latestOppfolgingstilfelle.toAktivitetskrav(),
-                )
+                createAktivitetskrav(connection = connection, oppfolgingstilfelle = latestOppfolgingstilfelle)
                 COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
             } else if (latestAktivitetskravForTilfelle.isVurdert() && latestOppfolgingstilfelle.isGradertAtTilfelleEnd()) {
                 log.info("Found vurdert aktivitetskrav and Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid} gradert - creating aktivitetskrav")
-                aktivitetskravService.createAktivitetskrav(
-                    connection = connection,
-                    aktivitetskrav = latestOppfolgingstilfelle.toAktivitetskrav(),
-                )
+                createAktivitetskrav(connection = connection, oppfolgingstilfelle = latestOppfolgingstilfelle)
                 COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
             } else {
                 log.info("Updating aktivitetskrav for Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid}")
@@ -120,6 +111,17 @@ class KafkaOppfolgingstilfellePersonService(
                 COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_UPDATED.increment()
             }
         }
+    }
+
+    private fun createAktivitetskrav(
+        connection: Connection,
+        oppfolgingstilfelle: Oppfolgingstilfelle,
+    ) {
+        aktivitetskravService.createAktivitetskrav(
+            connection = connection,
+            aktivitetskrav = oppfolgingstilfelle.toAktivitetskrav(),
+            referanseTilfelleBitUUID = oppfolgingstilfelle.referanseTilfelleBitUuid,
+        )
     }
 
     private fun notRelevantForAktivitetskrav(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean =

--- a/src/main/resources/db/migration/V1_9__add_referanse_tilfellebit_uuid.sql
+++ b/src/main/resources/db/migration/V1_9__add_referanse_tilfellebit_uuid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE AKTIVITETSKRAV
+    ADD COLUMN referanse_tilfelle_bit_uuid CHAR(36);

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -11,7 +11,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
-import java.util.EnumSet
+import java.util.*
 
 private val sevenWeeksAgo = LocalDate.now().minusWeeks(7)
 private val nineWeeksAgo = LocalDate.now().minusWeeks(9)
@@ -27,11 +27,10 @@ class AktivitetskravSpek : Spek({
 
     describe("gjelder Oppfolgingstilfelle") {
         it("returns false when different arbeidstakere") {
-            val aktivitetskrav =
-                Aktivitetskrav.ny(
-                    personIdent = OTHER_ARBEIDSTAKER_PERSONIDENT,
-                    tilfelleStart = nineWeeksAgo
-                )
+            val aktivitetskrav = createAktivitetskravNy(
+                personIdent = OTHER_ARBEIDSTAKER_PERSONIDENT,
+                tilfelleStart = nineWeeksAgo,
+            )
 
             aktivitetskrav gjelder oppfolgingstilfelle shouldBeEqualTo false
         }

--- a/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/identhendelse/IdenthendelseServiceSpek.kt
@@ -3,17 +3,15 @@ package no.nav.syfo.identhendelse
 import io.ktor.server.testing.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
-import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.testhelper.*
-import no.nav.syfo.testhelper.generator.generateKafkaIdenthendelseDTO
+import no.nav.syfo.testhelper.generator.*
 import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.lang.IllegalStateException
 import java.time.LocalDate
 
 private val aktivIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
@@ -45,9 +43,15 @@ class IdenthendelseServiceSpek : Spek({
             }
 
             describe("Aktivitetskrav eksisterer for person") {
-                val aktivitetskravNy = Aktivitetskrav.ny(inaktivIdent, LocalDate.now().minusDays(50))
+                val aktivitetskravNy = createAktivitetskravNy(
+                    personIdent = inaktivIdent,
+                    tilfelleStart = LocalDate.now().minusDays(50),
+                )
                 val aktivitetskravAutomatiskOppfylt =
-                    Aktivitetskrav.automatiskOppfylt(inaktivIdent, LocalDate.now().minusDays(400))
+                    createAktivitetskravAutomatiskOppfylt(
+                        personIdent = inaktivIdent,
+                        tilfelleStart = LocalDate.now().minusDays(400),
+                    )
                 beforeEachTest {
                     database.createAktivitetskrav(aktivitetskravNy, aktivitetskravAutomatiskOppfylt)
                 }

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -141,6 +141,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                     val aktivitetskrav = aktivitetskravList.first()
                     aktivitetskrav.status shouldBeEqualTo AktivitetskravStatus.NY.name
                     aktivitetskrav.stoppunktAt shouldBeEqualTo nineWeeksAgo.plusWeeks(8)
+                    aktivitetskrav.referanseTilfelleBitUuid.toString() shouldBeEqualTo kafkaOppfolgingstilfelleNineWeeksNotGradert.referanseTilfelleBitUuid
 
                     val kafkaRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
                     verify(exactly = 1) { kafkaProducer.send(capture(kafkaRecordSlot)) }
@@ -173,6 +174,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                     val aktivitetskrav = aktivitetskravList.first()
                     aktivitetskrav.status shouldBeEqualTo AktivitetskravStatus.AUTOMATISK_OPPFYLT.name
                     aktivitetskrav.stoppunktAt shouldBeEqualTo nineWeeksAgo.plusWeeks(8)
+                    aktivitetskrav.referanseTilfelleBitUuid.toString() shouldBeEqualTo kafkaOppfolgingstilfelleNineWeeksGradert.referanseTilfelleBitUuid
 
                     val kafkaRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
                     verify(exactly = 1) { kafkaProducer.send(capture(kafkaRecordSlot)) }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -6,6 +6,7 @@ import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.application.database.DatabaseInterface
 import org.flywaydb.core.Flyway
 import java.sql.Connection
+import java.util.*
 
 class TestDatabase : DatabaseInterface {
     private val pg: EmbeddedPostgres = try {
@@ -49,7 +50,7 @@ fun DatabaseInterface.dropData() {
 fun DatabaseInterface.createAktivitetskrav(vararg aktivitetskrav: Aktivitetskrav) {
     this.connection.use { connection ->
         aktivitetskrav.forEach {
-            connection.createAktivitetskrav(it)
+            connection.createAktivitetskrav(aktivitetskrav = it, referanseTilfelleBitUUID = UUID.randomUUID())
         }
         connection.commit()
     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
@@ -2,16 +2,23 @@ package no.nav.syfo.testhelper.generator
 
 import no.nav.syfo.aktivitetskrav.domain.*
 import no.nav.syfo.aktivitetskrav.domain.vurder
+import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.testhelper.UserConstants
 import java.time.LocalDate
 
-fun createAktivitetskravNy(tilfelleStart: LocalDate): Aktivitetskrav = Aktivitetskrav.ny(
-    personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+fun createAktivitetskravNy(
+    tilfelleStart: LocalDate,
+    personIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+): Aktivitetskrav = Aktivitetskrav.ny(
+    personIdent = personIdent,
     tilfelleStart = tilfelleStart,
 )
 
-fun createAktivitetskravAutomatiskOppfylt(tilfelleStart: LocalDate): Aktivitetskrav = Aktivitetskrav.automatiskOppfylt(
-    personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+fun createAktivitetskravAutomatiskOppfylt(
+    tilfelleStart: LocalDate,
+    personIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+): Aktivitetskrav = Aktivitetskrav.automatiskOppfylt(
+    personIdent = personIdent,
     tilfelleStart = tilfelleStart,
 )
 


### PR DESCRIPTION
Kan være nyttig å lagre denne for å lette feilsøking/analyse av hvilken tilfelle-bit som har ført til at et aktivitetskrav har blitt generert. Feltet vil være null for aktivitetskrav som er opprettet uten oppfølgingstilfelle (dvs av veileder i Modia - f.eks. for utenlandske sykmeldte)