### PR TITLE
Delete aktivitetskrav vurdering made on wrong person

### DIFF
--- a/src/main/resources/db/migration/V2_5__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V2_5__delete_wrong_vurdering.sql
@@ -1,0 +1,6 @@
+DELETE FROM aktivitetskrav_vurdering WHERE uuid = '9222d187-55d6-4b38-9a83-6a6832bc60aa';
+
+UPDATE aktivitetskrav
+SET status = 'NY',
+    updated_at = now()
+WHERE uuid = 'ee6134d4-7428-4d56-809d-3f68357554ed';


### PR DESCRIPTION
https://jira.adeo.no/browse/FAGSYSTEM-284852

Tanken er at veileder kan gå inn å gjøre riktig aktivitetskrav-vurdering etterpå så vi trenger ikke lage script som oppdaterer status til NY i syfooversiktsrv.