### PR TITLE
Cronjob for deleting wrong vurdering and updating aktivitetskrav

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/DeleteVurderingCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/DeleteVurderingCronjob.kt
@@ -1,0 +1,57 @@
+package no.nav.syfo.aktivitetskrav.cronjob
+
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.aktivitetskrav.AktivitetskravService
+import no.nav.syfo.aktivitetskrav.database.getAktivitetskravVurdering
+import no.nav.syfo.application.cronjob.Cronjob
+import no.nav.syfo.application.cronjob.CronjobResult
+import no.nav.syfo.application.database.DatabaseInterface
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class DeleteVurderingCronjob(
+    private val database: DatabaseInterface,
+    private val aktivitetskravService: AktivitetskravService,
+) : Cronjob {
+
+    override val initialDelayMinutes: Long = 3
+    override val intervalDelayMinutes: Long = 240
+
+    override suspend fun run() {
+        val result = runJob(uuids.map { UUID.fromString(it) })
+        log.info(
+            "Completed delete vurdering job with result: {}, {}",
+            StructuredArguments.keyValue("failed", result.failed),
+            StructuredArguments.keyValue("updated", result.updated),
+        )
+    }
+
+    fun runJob(vurderingUuids: List<UUID>): CronjobResult {
+        val result = CronjobResult()
+        val aktivitetskravVurderinger = vurderingUuids.mapNotNull { database.getAktivitetskravVurdering(it) }
+        log.info("Cronjob for delete vurdering found ${aktivitetskravVurderinger.size} vurderinger")
+        aktivitetskravVurderinger.forEach {
+            try {
+                database.connection.use { connection ->
+                    aktivitetskravService.deleteVurdering(
+                        connection = connection,
+                        vurdering = it
+                    )
+                    connection.commit()
+                    log.info("Vurdering with uuid ${it.uuid} deleted")
+                }
+                result.updated++
+            } catch (e: Exception) {
+                log.error("Caught exception in delete vurdering job")
+                result.failed++
+            }
+        }
+
+        return result
+    }
+
+    companion object {
+        private val uuids = emptyList<String>()
+        private val log = LoggerFactory.getLogger(DeleteVurderingCronjob::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -150,3 +150,7 @@ internal fun Aktivitetskrav.vurder(
 internal fun Aktivitetskrav.oppfyllAutomatisk(): Aktivitetskrav = this.copy(
     status = AktivitetskravStatus.AUTOMATISK_OPPFYLT,
 )
+
+internal fun Aktivitetskrav.updateStatusFromVurderinger(): Aktivitetskrav = this.copy(
+    status = this.vurderinger.firstOrNull()?.status ?: AktivitetskravStatus.NY,
+)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/DeleteVurderingCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/DeleteVurderingCronjobSpek.kt
@@ -1,0 +1,160 @@
+package no.nav.syfo.aktivitetskrav.cronjob
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.aktivitetskrav.AktivitetskravService
+import no.nav.syfo.aktivitetskrav.database.createAktivitetskrav
+import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
+import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
+import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVurdering
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.generator.*
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.producer.*
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+import java.util.concurrent.Future
+
+class DeleteVurderingCronjobSpek : Spek({
+    with(TestApplicationEngine()) {
+        start()
+
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+
+        val kafkaProducer = mockk<KafkaProducer<String, KafkaAktivitetskravVurdering>>()
+        val aktivitetskravVurderingProducer =
+            AktivitetskravVurderingProducer(kafkaProducerAktivitetskravVurdering = kafkaProducer)
+
+        val aktivitetskravService = AktivitetskravService(
+            database = database,
+            aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
+            arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
+        )
+
+        val deleteVurderingCronjob = DeleteVurderingCronjob(
+            database = database,
+            aktivitetskravService = aktivitetskravService,
+        )
+
+        beforeEachTest {
+            clearMocks(kafkaProducer)
+            coEvery {
+                kafkaProducer.send(any())
+            } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        }
+        afterEachTest {
+            database.dropData()
+        }
+
+        describe(DeleteVurderingCronjob::class.java.simpleName) {
+            val aktivitetskravNy = createAktivitetskravNy(
+                tilfelleStart = LocalDate.now().minusWeeks(50),
+            )
+
+            it("Sletter ingen vurdering når tom liste med uuider") {
+                database.createAktivitetskrav(aktivitetskravNy)
+                val unntakVurdering = createUnntakVurdering()
+                aktivitetskravService.vurderAktivitetskrav(
+                    aktivitetskrav = aktivitetskravNy,
+                    aktivitetskravVurdering = unntakVurdering
+                )
+
+                clearMocks(kafkaProducer)
+                coEvery {
+                    kafkaProducer.send(any())
+                } returns mockk<Future<RecordMetadata>>(relaxed = true)
+                runBlocking {
+                    val result = deleteVurderingCronjob.runJob(emptyList())
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 0
+                }
+
+                val aktivitetskrav = aktivitetskravService.getAktivitetskrav(aktivitetskravNy.uuid)!!
+                aktivitetskrav.status shouldBeEqualTo AktivitetskravStatus.UNNTAK
+                aktivitetskrav.vurderinger.size shouldBeEqualTo 1
+                aktivitetskrav.vurderinger.first().uuid shouldBeEqualTo unntakVurdering.uuid
+
+                val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
+                verify(exactly = 0) {
+                    kafkaProducer.send(capture(producerRecordSlot))
+                }
+            }
+
+            it("Sletter angitt vurdering og oppdaterer aktivitetskrav-status til NY når ingen andre vurderinger eksisterer") {
+                database.createAktivitetskrav(aktivitetskravNy)
+                val unntakVurdering = createUnntakVurdering()
+                aktivitetskravService.vurderAktivitetskrav(
+                    aktivitetskrav = aktivitetskravNy,
+                    aktivitetskravVurdering = unntakVurdering
+                )
+
+                clearMocks(kafkaProducer)
+                coEvery {
+                    kafkaProducer.send(any())
+                } returns mockk<Future<RecordMetadata>>(relaxed = true)
+                runBlocking {
+                    val result = deleteVurderingCronjob.runJob(listOf(unntakVurdering.uuid))
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 1
+                }
+
+                val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
+                verify(exactly = 1) {
+                    kafkaProducer.send(capture(producerRecordSlot))
+                }
+
+                val aktivitetskrav = aktivitetskravService.getAktivitetskrav(aktivitetskravNy.uuid)!!
+                aktivitetskrav.status shouldBeEqualTo AktivitetskravStatus.NY
+                aktivitetskrav.vurderinger.shouldBeEmpty()
+
+                val kafkaAktivitetskravVurdering = producerRecordSlot.captured.value()
+                kafkaAktivitetskravVurdering.status shouldBeEqualTo aktivitetskrav.status.name
+            }
+
+            it("Sletter angitt vurdering og oppdaterer aktivitetskrav-status til forrige vurdering") {
+                database.createAktivitetskrav(aktivitetskravNy)
+                val avventVurdering = createAvventVurdering()
+                aktivitetskravService.vurderAktivitetskrav(
+                    aktivitetskrav = aktivitetskravNy,
+                    aktivitetskravVurdering = avventVurdering
+                )
+                val unntakVurdering = createUnntakVurdering()
+                aktivitetskravService.vurderAktivitetskrav(
+                    aktivitetskrav = aktivitetskravNy,
+                    aktivitetskravVurdering = unntakVurdering
+                )
+
+                clearMocks(kafkaProducer)
+                coEvery {
+                    kafkaProducer.send(any())
+                } returns mockk<Future<RecordMetadata>>(relaxed = true)
+                runBlocking {
+                    val result = deleteVurderingCronjob.runJob(listOf(unntakVurdering.uuid))
+
+                    result.failed shouldBeEqualTo 0
+                    result.updated shouldBeEqualTo 1
+                }
+
+                val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
+                verify(exactly = 1) {
+                    kafkaProducer.send(capture(producerRecordSlot))
+                }
+
+                val aktivitetskrav = aktivitetskravService.getAktivitetskrav(aktivitetskravNy.uuid)!!
+                aktivitetskrav.status shouldBeEqualTo AktivitetskravStatus.AVVENT
+                aktivitetskrav.vurderinger.size shouldBeEqualTo 1
+                aktivitetskrav.vurderinger.first().uuid shouldBeEqualTo avventVurdering.uuid
+
+                val kafkaAktivitetskravVurdering = producerRecordSlot.captured.value()
+                kafkaAktivitetskravVurdering.status shouldBeEqualTo aktivitetskrav.status.name
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
@@ -33,24 +33,28 @@ fun createAktivitetskravOppfylt(nyAktivitetskrav: Aktivitetskrav): Aktivitetskra
 }
 
 fun createAktivitetskravAvvent(nyAktivitetskrav: Aktivitetskrav): Aktivitetskrav {
-    val avventVurdering = AktivitetskravVurdering.create(
-        status = AktivitetskravStatus.AVVENT,
-        createdBy = UserConstants.VEILEDER_IDENT,
-        beskrivelse = "Avvent",
-        arsaker = listOf(VurderingArsak.INFORMASJON_BEHANDLER, VurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER),
-    )
+    val avventVurdering = createAvventVurdering()
     return nyAktivitetskrav.vurder(avventVurdering)
 }
 
+fun createAvventVurdering() = AktivitetskravVurdering.create(
+    status = AktivitetskravStatus.AVVENT,
+    createdBy = UserConstants.VEILEDER_IDENT,
+    beskrivelse = "Avvent",
+    arsaker = listOf(VurderingArsak.INFORMASJON_BEHANDLER, VurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER),
+)
+
 fun createAktivitetskravUnntak(nyAktivitetskrav: Aktivitetskrav): Aktivitetskrav {
-    val unntakVurdering = AktivitetskravVurdering.create(
-        status = AktivitetskravStatus.UNNTAK,
-        createdBy = UserConstants.VEILEDER_IDENT,
-        beskrivelse = "Unntak",
-        arsaker = listOf(VurderingArsak.SJOMENN_UTENRIKS),
-    )
+    val unntakVurdering = createUnntakVurdering()
     return nyAktivitetskrav.vurder(unntakVurdering)
 }
+
+fun createUnntakVurdering() = AktivitetskravVurdering.create(
+    status = AktivitetskravStatus.UNNTAK,
+    createdBy = UserConstants.VEILEDER_IDENT,
+    beskrivelse = "Unntak",
+    arsaker = listOf(VurderingArsak.SJOMENN_UTENRIKS),
+)
 
 fun createAktivitetskravIkkeOppfylt(nyAktivitetskrav: Aktivitetskrav): Aktivitetskrav {
     val ikkeOppfyltVurdering = AktivitetskravVurdering.create(


### PR DESCRIPTION
Tanken er at jobben tar inn en liste med uuid-er til vurderinger som skal slettes. Når en vurdering slettes hentes tilhørende aktivitetskrav og status til aktivitetskravet oppdateres til forrige vurdering (eller NY dersom det ikke finnes andre vurderinger av dette aktivitetskravet). Oppdatert aktivitetskrav sendes så på Kafka (slik at f.eks. syfooversikt får oppdatert aktivitetskrav).