### PR TITLE
Fix frist

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/ForhandsvarselDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/ForhandsvarselDTO.kt
@@ -13,6 +13,6 @@ data class ForhandsvarselDTO(
         createdBy = veilederIdent,
         beskrivelse = this.fritekst,
         arsaker = emptyList(),
-        frist = LocalDate.now().plusWeeks(2),
+        frist = LocalDate.now().plusWeeks(3), // På sikt avhengig av om bruker er reservert mot digital kommunikasjon eller ikke
     )
 }


### PR DESCRIPTION
Setter 3 uker som frist på vurderingen (fristen bruker har på å svare)

Ideelt sett burde vi kanskje la frist på vurderingen handle om når veileder skal plukke opp vurderingen igjen (når oppgave skal lages - dvs 3 + 1 uker). Og så ha et eget frist-konsept på varselet som som beskriver fristen bruker har på å svare på varselet. Tenker vi kan diskutere det videre og evt lage ny PR på det. Da må vi evt også tilpasse GET-apiet til å hente ut varselet med fristen til bruker så dette kan vises i frontend.
