### PR TITLE
Add metrics to aktivitetskravvurdering that is published to kafka

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravMetrics.kt
@@ -1,0 +1,50 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.application.metric.METRICS_NS
+import no.nav.syfo.application.metric.METRICS_REGISTRY
+
+const val AKTIVITETSKRAV_KAFKA_METRIC_BASE = "${METRICS_NS}_kafka_producer"
+const val AKTIVITETSKRAV_VURDERING_KAFKA = "${AKTIVITETSKRAV_KAFKA_METRIC_BASE}_vurdering"
+const val UNNTAK = "${AKTIVITETSKRAV_VURDERING_KAFKA}_unntak"
+const val AVVENT = "${AKTIVITETSKRAV_VURDERING_KAFKA}_avvent"
+const val OPPFYLT = "${AKTIVITETSKRAV_VURDERING_KAFKA}_oppfylt"
+const val STANS = "${AKTIVITETSKRAV_VURDERING_KAFKA}_stans"
+const val FORHANDSVARSEL = "${AKTIVITETSKRAV_VURDERING_KAFKA}_forhandsvarsel"
+const val IKKE_OPPFYLT = "${AKTIVITETSKRAV_VURDERING_KAFKA}_ikke_oppfylt"
+const val IKKE_AKTUELL = "${AKTIVITETSKRAV_VURDERING_KAFKA}_ikke_aktuell"
+
+val COUNT_FORHANDSVARSEL: Counter =
+    Counter.builder(FORHANDSVARSEL)
+        .description("Counts the number vurderinger with status FORHANDSVARSEL created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_UNNTAK: Counter =
+    Counter.builder(UNNTAK)
+        .description("Counts the number vurderinger with status UNNTAK created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_AVVENT: Counter =
+    Counter.builder(AVVENT)
+        .description("Counts the number vurderinger with status AVVENT created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_OPPFYLT: Counter =
+    Counter.builder(OPPFYLT)
+        .description("Counts the number vurderinger with status OPPFYLT created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_STANS: Counter =
+    Counter.builder(STANS)
+        .description("Counts the number vurderinger with status STANS created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_IKKE_OPPFYLT: Counter =
+    Counter.builder(IKKE_OPPFYLT)
+        .description("Counts the number vurderinger with status IKKE_OPPFYLT created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_IKKE_AKTUELL: Counter =
+    Counter.builder(IKKE_AKTUELL)
+        .description("Counts the number vurderinger with status IKKE_AKTUELL created")
+        .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.aktivitetskrav.kafka
 
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.domain.toKafkaAktivitetskravVurdering
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -23,6 +24,20 @@ class AktivitetskravVurderingProducer(
                     kafkaAktivitetskravVurdering,
                 )
             ).get()
+            log.info(
+                "Aktivitetskravvurdering sent with status: {} for uuid: {}",
+                kafkaAktivitetskravVurdering.status,
+                kafkaAktivitetskravVurdering.uuid
+            )
+            when (kafkaAktivitetskravVurdering.status) {
+                AktivitetskravStatus.AVVENT.name -> COUNT_AVVENT.increment()
+                AktivitetskravStatus.UNNTAK.name -> COUNT_UNNTAK.increment()
+                AktivitetskravStatus.OPPFYLT.name -> COUNT_OPPFYLT.increment()
+                AktivitetskravStatus.FORHANDSVARSEL.name -> COUNT_FORHANDSVARSEL.increment()
+                AktivitetskravStatus.STANS.name -> COUNT_STANS.increment()
+                AktivitetskravStatus.IKKE_OPPFYLT.name -> COUNT_IKKE_OPPFYLT.increment()
+                AktivitetskravStatus.IKKE_AKTUELL.name -> COUNT_IKKE_AKTUELL.increment()
+            }
         } catch (e: Exception) {
             log.error(
                 "Exception was thrown when attempting to send KafkaAktivitetskravVurdering with id {}: ${e.message}",


### PR DESCRIPTION
Vil ha dette inn i grafana - særlig forhåndsvarselet.
Dropper foreløpig typene NY, AUTOMATISK_OPPFYLT og LUKKET, litt usikker på om det er interessant å telle de?