### PR TITLE
Move linger config to vurdering producer

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -8,7 +8,7 @@ import io.ktor.server.netty.*
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
 import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
-import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVurderingSerializer
+import no.nav.syfo.aktivitetskrav.kafka.aktivitetskravVurderingProducerConfig
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
 import no.nav.syfo.application.api.apiModule
@@ -16,7 +16,6 @@ import no.nav.syfo.application.cache.RedisStore
 import no.nav.syfo.application.cronjob.launchCronjobModule
 import no.nav.syfo.application.database.applicationDatabase
 import no.nav.syfo.application.database.databaseModule
-import no.nav.syfo.application.kafka.kafkaAivenProducerConfig
 import no.nav.syfo.application.kafka.launchKafkaModule
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.pdfgen.PdfGenClient
@@ -72,9 +71,7 @@ fun main() {
 
     val aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(
         kafkaProducerAktivitetskravVurdering = KafkaProducer(
-            kafkaAivenProducerConfig<KafkaAktivitetskravVurderingSerializer>(
-                kafkaEnvironment = environment.kafka,
-            )
+            aktivitetskravVurderingProducerConfig(kafkaEnvironment = environment.kafka)
         )
     )
     lateinit var aktivitetskravService: AktivitetskravService

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
@@ -3,7 +3,10 @@ package no.nav.syfo.aktivitetskrav.kafka
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.domain.toKafkaAktivitetskravVurdering
+import no.nav.syfo.application.kafka.KafkaEnvironment
+import no.nav.syfo.application.kafka.kafkaAivenProducerConfig
 import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
 import java.util.*
@@ -52,3 +55,8 @@ class AktivitetskravVurderingProducer(
         private val log = LoggerFactory.getLogger(AktivitetskravVurderingProducer::class.java)
     }
 }
+
+fun aktivitetskravVurderingProducerConfig(kafkaEnvironment: KafkaEnvironment) =
+    kafkaAivenProducerConfig<KafkaAktivitetskravVurderingSerializer>(kafkaEnvironment).apply {
+        this[ProducerConfig.LINGER_MS_CONFIG] = "1000"
+    }

--- a/src/main/kotlin/no/nav/syfo/application/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/application/kafka/KafkaConfig.kt
@@ -35,7 +35,6 @@ inline fun <reified Serializer> kafkaAivenProducerConfig(
         this[ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION] = "1"
         this[ProducerConfig.MAX_BLOCK_MS_CONFIG] = "15000"
         this[ProducerConfig.RETRIES_CONFIG] = "100000"
-        this[ProducerConfig.LINGER_MS_CONFIG] = "1000"
         this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.canonicalName
         this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = Serializer::class.java.canonicalName
     }


### PR DESCRIPTION
Flytter denne slik at den bare gjelder AktivitetskravVurderingProducer. Det ble lagt på "linger" her for å forsinke publisering av aktivitetskrav til syfooversikt og unngå samtidighetskonflikt der.