### PR TITLE
Slett feilregistrert vurdering

### DIFF
--- a/src/main/resources/db/migration/V2_9__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V2_9__delete_wrong_vurdering.sql
@@ -1,0 +1,1 @@
+DELETE FROM aktivitetskrav_vurdering WHERE uuid = '837adbb9-374f-4fd4-aa74-642a3c9371bb';


### PR DESCRIPTION
Veileder har registrert et korrekt unntak etterpå, så vi trenger bare fjerne den feilregistrerte vurderingen.