### PR TITLE
Add aktivitetskrav-varsel kafka topic and produce

### DIFF
--- a/.github/workflows/kafka-aktivitetskrav.yaml
+++ b/.github/workflows/kafka-aktivitetskrav.yaml
@@ -6,33 +6,51 @@ on:
       - master
     paths:
       - '.github/workflows/kafka-aktivitetskrav.yaml'
-      - '.nais/kafka/aktivitetskrav.yaml'
-      - '.nais/kafka/dev.json'
-      - '.nais/kafka/prod.json'
+      - '.nais/kafka/**'
 
 jobs:
   deploy-kafka-aktivitetskrav-dev:
-    name: Deploy Kafka topic Aktivitetskrav to NAIS dev-gcp
+    name: Deploy Kafka topics to dev-gcp
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v1
+
+      - name: Deploy aktivitetskrav-vurdering topic to dev
+        uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: dev-gcp
           RESOURCE: .nais/kafka/aktivitetskrav.yaml
           VARS: .nais/kafka/dev.json
 
+      - name: Deploy aktivitetskrav-varsel topic to dev
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/kafka/aktivitetskrav-varsel.yaml
+          VARS: .nais/kafka/dev.json
+
   deploy-kafka-aktivitetskrav-prod:
-    name: Deploy Kafka topic Aktivitetskrav to NAIS prod-gcp
+    name: Deploy Kafka topics to prod-gcp
     needs: deploy-kafka-aktivitetskrav-dev
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v1
+
+      - name: Deploy aktivitetskrav-vurdering topic to prod
+        uses: nais/deploy/actions/deploy@v1
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp
           RESOURCE: .nais/kafka/aktivitetskrav.yaml
+          VARS: .nais/kafka/prod.json
+
+      - name: Deploy aktivitetskrav-varsel topic to prod
+        uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/kafka/aktivitetskrav-varsel.yaml
           VARS: .nais/kafka/prod.json
 

--- a/.nais/kafka/aktivitetskrav-varsel.yaml
+++ b/.nais/kafka/aktivitetskrav-varsel.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  annotations:
+    dcat.data.nav.no/title: "Aktivitetskrav-varsel for sykmeldte personer"
+    dcat.data.nav.no/description: >-
+      Topic inneholder informasjon om aktivitetskrav-varsler sendt til sykmeldte personer.
+  name: aktivitetskrav-varsel
+  namespace: teamsykefravr
+  labels:
+    team: teamsykefravr
+spec:
+  pool: {{ kafkaPool }}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: -1  # -1 means unlimited
+  acl:
+    - team: teamsykefravr
+      application: isaktivitetskrav
+      access: readwrite
+    - team: team-esyfo
+      application: aktivitetskrav-backend
+      access: read

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjob.kt
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 class PubliserAktivitetskravVarselCronjob(
     private val aktivitetskravVarselRepository: AktivitetskravVarselRepository,
     private val arbeidstakervarselProducer: ArbeidstakervarselProducer,
+    private val aktivitetskravVarselProducer: AktivitetskravVarselProducer,
 ) : Cronjob {
     override val initialDelayMinutes: Long = 7
     override val intervalDelayMinutes: Long = 10
@@ -25,22 +26,29 @@ class PubliserAktivitetskravVarselCronjob(
 
     fun runJob(): CronjobResult {
         val result = CronjobResult()
-        aktivitetskravVarselRepository.getIkkePubliserte().forEach { (personIdent, pAktivitetskravVarsel) ->
+        aktivitetskravVarselRepository.getIkkePubliserte().forEach { (personIdent, pAktivitetskravVarsel, aktivitetskravUuid) ->
             try {
+                val varsel = pAktivitetskravVarsel.toAktivitetkravVarsel()
+                aktivitetskravVarselProducer.sendAktivitetskravVarsel(
+                    personIdent = personIdent,
+                    aktivitetskravUuid = aktivitetskravUuid,
+                    varsel = varsel,
+                )
+                // TODO: Koden under kan fjernes når eSyfo konsumerer varselet over og sender til esyfovarsel
                 arbeidstakervarselProducer.sendArbeidstakervarsel(
                     varselHendelse = ArbeidstakerHendelse(
                         type = HendelseType.SM_FORHANDSVARSEL_STANS,
                         arbeidstakerFnr = personIdent.value,
                         data = VarselData(
                             journalpost = VarselDataJournalpost(
-                                uuid = pAktivitetskravVarsel.uuid.toString(),
-                                id = pAktivitetskravVarsel.journalpostId.toString(),
+                                uuid = varsel.uuid.toString(),
+                                id = varsel.journalpostId,
                             ),
                         ),
                         orgnummer = null,
                     )
                 )
-                aktivitetskravVarselRepository.setPublished(pAktivitetskravVarsel.toAktivitetkravVarsel())
+                aktivitetskravVarselRepository.setPublished(varsel)
                 result.updated++
             } catch (e: Exception) {
                 log.error("Exception caught while attempting publisering of aktivitetskrav-varsel", e)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -47,7 +47,7 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
 
     fun getIkkeJournalforte(): List<Triple<PersonIdent, PAktivitetskravVarsel, ByteArray>> = database.getIkkeJournalforteVarsler()
 
-    fun getIkkePubliserte(): List<Pair<PersonIdent, PAktivitetskravVarsel>> = database.getIkkePubliserteVarsler()
+    fun getIkkePubliserte(): List<Triple<PersonIdent, PAktivitetskravVarsel, UUID>> = database.getIkkePubliserteVarsler()
 
     fun updateJournalpostId(varsel: AktivitetskravVarsel, journalpostId: String) =
         database.updateVarselJournalpostId(varsel, journalpostId)
@@ -74,11 +74,10 @@ private fun Connection.createAktivitetskravVarsel(
     vurderingId: Int,
     varsel: AktivitetskravVarsel
 ): PAktivitetskravVarsel {
-    val now = nowUTC()
     val varsler = this.prepareStatement(queryCreateAktivitetskravVarsel).use {
         it.setString(1, varsel.uuid.toString())
-        it.setObject(2, now)
-        it.setObject(3, now)
+        it.setObject(2, varsel.createdAt)
+        it.setObject(3, nowUTC())
         it.setInt(4, vurderingId)
         it.setObject(5, mapper.writeValueAsString(varsel.document))
         it.setNull(6, Types.VARCHAR)
@@ -162,7 +161,7 @@ private fun DatabaseInterface.updateVarselJournalpostId(varsel: AktivitetskravVa
 }
 
 private const val queryGetIkkePubliserteVarsler = """
-    SELECT av.*, a.personident as personident 
+    SELECT av.*, a.personident as personident, a.uuid as aktivitetskravUuid 
     FROM aktivitetskrav_varsel av 
     INNER JOIN aktivitetskrav_vurdering avu
     ON av.aktivitetskrav_vurdering_id = avu.id
@@ -171,13 +170,14 @@ private const val queryGetIkkePubliserteVarsler = """
     WHERE av.journalpost_id IS NOT NULL and av.published_at IS NULL
 """
 
-private fun DatabaseInterface.getIkkePubliserteVarsler(): List<Pair<PersonIdent, PAktivitetskravVarsel>> {
+private fun DatabaseInterface.getIkkePubliserteVarsler(): List<Triple<PersonIdent, PAktivitetskravVarsel, UUID>> {
     return this.connection.use { connection ->
         connection.prepareStatement(queryGetIkkePubliserteVarsler).use {
             it.executeQuery().toList {
-                Pair(
+                Triple(
                     PersonIdent(getString("personident")),
                     toPAktivitetskravVarsel(),
+                    UUID.fromString(getString("aktivitetskravUuid")),
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/PAktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/PAktivitetskravVarsel.kt
@@ -17,6 +17,7 @@ data class PAktivitetskravVarsel(
 ) {
     fun toAktivitetkravVarsel() = AktivitetskravVarsel.createFromDatabase(
         uuid = uuid,
+        createdAt = createdAt,
         journalpostId = journalpostId,
         document = document,
         published = publishedAt != null,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
@@ -1,10 +1,13 @@
 package no.nav.syfo.aktivitetskrav.domain
 
 import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.util.nowUTC
+import java.time.OffsetDateTime
 import java.util.*
 
 data class AktivitetskravVarsel internal constructor(
     val uuid: UUID,
+    val createdAt: OffsetDateTime,
     val journalpostId: String?,
     val document: List<DocumentComponentDTO>,
     val isPublished: Boolean = false,
@@ -13,17 +16,20 @@ data class AktivitetskravVarsel internal constructor(
     companion object {
         fun create(document: List<DocumentComponentDTO>) = AktivitetskravVarsel(
             uuid = UUID.randomUUID(),
+            createdAt = nowUTC(),
             journalpostId = null,
             document = document,
         )
 
         fun createFromDatabase(
             uuid: UUID,
+            createdAt: OffsetDateTime,
             journalpostId: String?,
             document: List<DocumentComponentDTO>,
             published: Boolean,
         ) = AktivitetskravVarsel(
             uuid = uuid,
+            createdAt = createdAt,
             journalpostId = journalpostId,
             document = document,
             isPublished = published,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVarselProducer.kt
@@ -1,0 +1,47 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVarsel
+import no.nav.syfo.domain.PersonIdent
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.slf4j.LoggerFactory
+import java.util.*
+
+class AktivitetskravVarselProducer(private val kafkaProducer: KafkaProducer<String, KafkaAktivitetskravVarsel>) {
+
+    fun sendAktivitetskravVarsel(
+        personIdent: PersonIdent,
+        aktivitetskravUuid: UUID,
+        varsel: AktivitetskravVarsel,
+    ) {
+        val key = UUID.nameUUIDFromBytes(personIdent.value.toByteArray()).toString()
+        val kafkaAktivitetskravVarsel = KafkaAktivitetskravVarsel(
+            personIdent = personIdent.value,
+            aktivitetskravUuid = aktivitetskravUuid,
+            varselUuid = varsel.uuid,
+            createdAt = varsel.createdAt,
+            journalpostId = varsel.journalpostId!!,
+            document = varsel.document
+        )
+        try {
+            kafkaProducer.send(
+                ProducerRecord(
+                    AKTIVITETSKRAV_VARSEL_TOPIC,
+                    key,
+                    kafkaAktivitetskravVarsel,
+                )
+            ).get()
+        } catch (e: Exception) {
+            log.error(
+                "Exception was thrown when attempting to send KafkaAktivitetskravVarsel with id {}: ${e.message}",
+                key
+            )
+            throw e
+        }
+    }
+
+    companion object {
+        const val AKTIVITETSKRAV_VARSEL_TOPIC = "teamsykefravr.aktivitetskrav-varsel"
+        private val log = LoggerFactory.getLogger(AktivitetskravVarselProducer::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/KafkaAktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/KafkaAktivitetskravVarsel.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import java.time.OffsetDateTime
+import java.util.*
+
+data class KafkaAktivitetskravVarsel(
+    val personIdent: String,
+    val aktivitetskravUuid: UUID,
+    val varselUuid: UUID,
+    val createdAt: OffsetDateTime,
+    val journalpostId: String,
+    val document: List<DocumentComponentDTO>,
+)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/KafkaAktivitetskravVarselSerializer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/KafkaAktivitetskravVarselSerializer.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.aktivitetskrav.kafka
+
+import no.nav.syfo.util.configuredJacksonMapper
+import org.apache.kafka.common.serialization.Serializer
+
+class KafkaAktivitetskravVarselSerializer : Serializer<KafkaAktivitetskravVarsel> {
+    private val mapper = configuredJacksonMapper()
+    override fun serialize(topic: String?, data: KafkaAktivitetskravVarsel?): ByteArray =
+        mapper.writeValueAsBytes(data)
+}

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
@@ -4,10 +4,12 @@ import no.nav.syfo.aktivitetskrav.AktivitetskravService
 import no.nav.syfo.aktivitetskrav.cronjob.*
 import no.nav.syfo.aktivitetskrav.kafka.KafkaArbeidstakervarselSerializer
 import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
+import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVarselProducer
 import no.nav.syfo.application.*
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.kafka.kafkaAivenProducerConfig
 import no.nav.syfo.aktivitetskrav.kafka.ArbeidstakervarselProducer
+import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVarselSerializer
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.dokarkiv.DokarkivClient
 import no.nav.syfo.client.leaderelection.LeaderPodClient
@@ -46,6 +48,7 @@ fun launchCronjobModule(
         )
         cronjobs.add(aktivitetskravNyCronjob)
     }
+
     val dokarkivClient = DokarkivClient(
         azureAdClient = azureAdClient,
         dokarkivEnvironment = environment.clients.dokarkiv,
@@ -56,6 +59,7 @@ fun launchCronjobModule(
         pdlClient = pdlClient
     )
     cronjobs.add(journalforAktivitetskravVarselCronjob)
+
     val arbeidstakervarselProducer = ArbeidstakervarselProducer(
         kafkaArbeidstakervarselProducer = KafkaProducer(
             kafkaAivenProducerConfig<KafkaArbeidstakervarselSerializer>(
@@ -63,11 +67,20 @@ fun launchCronjobModule(
             )
         )
     )
+    val aktivitetskravVarselProducer = AktivitetskravVarselProducer(
+        kafkaProducer = KafkaProducer(
+            kafkaAivenProducerConfig<KafkaAktivitetskravVarselSerializer>(
+                kafkaEnvironment = environment.kafka,
+            )
+        )
+    )
     val publiserAktivitetskravVarselCronjob = PubliserAktivitetskravVarselCronjob(
         aktivitetskravVarselRepository = aktivitetskravVarselRepository,
         arbeidstakervarselProducer = arbeidstakervarselProducer,
+        aktivitetskravVarselProducer = aktivitetskravVarselProducer,
     )
     cronjobs.add(publiserAktivitetskravVarselCronjob)
+
     if (environment.outdatedCronJobEnabled) {
         val outdatedAktivitetskravCronjob = OutdatedAktivitetskravCronjob(
             outdatedCutoff = environment.outdatedCutoff,

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -11,4 +11,6 @@ fun tomorrow(): LocalDate = LocalDate.now().plusDays(1)
 
 fun OffsetDateTime.millisekundOpplosning(): OffsetDateTime = this.truncatedTo(ChronoUnit.MILLIS)
 
+fun OffsetDateTime.sekundOpplosning(): OffsetDateTime = this.truncatedTo(ChronoUnit.SECONDS)
+
 fun LocalDate.isAfterOrEqual(date: LocalDate) = !this.isBefore(date)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
@@ -17,6 +17,7 @@ import no.nav.syfo.client.dokarkiv.domain.JournalpostResponse
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.testhelper.generator.generateForhandsvarsel
 import no.nav.syfo.testhelper.generator.generateJournalpostRequest
+import no.nav.syfo.util.sekundOpplosning
 import org.amshove.kluent.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -175,7 +176,7 @@ class JournalforAktivitetskravVarselCronjobSpek : Spek({
                 val first = varsler.first()
                 first.uuid shouldBeEqualTo varsel.uuid
                 first.journalpostId.shouldBeNull()
-                first.updatedAt shouldBeEqualTo first.createdAt
+                first.updatedAt.sekundOpplosning() shouldBeEqualTo first.createdAt.sekundOpplosning()
             }
             it("Oppdaterer ikke journalpostId når journalføring feiler") {
                 val expectedJournalpostRequestForhandsvarsel = generateJournalpostRequest(
@@ -205,7 +206,7 @@ class JournalforAktivitetskravVarselCronjobSpek : Spek({
                 val first = varsler.first()
                 first.uuid shouldBeEqualTo varsel.uuid
                 first.journalpostId.shouldBeNull()
-                first.updatedAt shouldBeEqualTo first.createdAt
+                first.updatedAt.sekundOpplosning() shouldBeEqualTo first.createdAt.sekundOpplosning()
             }
         }
     }


### PR DESCRIPTION
Publiserer aktivitetskrav-varsel-data (journalpostId og document) på egen topic som eSyfo kan konsumere for å vise fram forhåndsvarsel