### PR TITLE
Refactor to AktivitetskravVarselService

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -1,14 +1,9 @@
 package no.nav.syfo.aktivitetskrav
 
-import no.nav.syfo.aktivitetskrav.api.ForhandsvarselDTO
 import no.nav.syfo.aktivitetskrav.database.*
 import no.nav.syfo.aktivitetskrav.domain.*
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
 import no.nav.syfo.application.database.DatabaseInterface
-import no.nav.syfo.client.krr.KRRClient
-import no.nav.syfo.client.pdfgen.ForhandsvarselPdfDTO
-import no.nav.syfo.client.pdfgen.PdfGenClient
-import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.oppfolgingstilfelle.domain.Oppfolgingstilfelle
 import java.sql.Connection
@@ -17,12 +12,8 @@ import java.util.*
 
 class AktivitetskravService(
     private val aktivitetskravVurderingProducer: AktivitetskravVurderingProducer,
-    private val aktivitetskravVarselRepository: AktivitetskravVarselRepository,
     private val database: DatabaseInterface,
     private val arenaCutoff: LocalDate,
-    private val pdfGenClient: PdfGenClient,
-    private val pdlClient: PdlClient,
-    private val krrClient: KRRClient,
 ) {
 
     internal fun createAktivitetskrav(
@@ -154,39 +145,5 @@ class AktivitetskravService(
         aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
             aktivitetskrav = updatedAktivitetskrav
         )
-    }
-
-    suspend fun sendForhandsvarsel(
-        aktivitetskrav: Aktivitetskrav,
-        veilederIdent: String,
-        personIdent: PersonIdent,
-        forhandsvarselDTO: ForhandsvarselDTO,
-        callId: String,
-    ): AktivitetskravVarsel {
-        val personNavn = pdlClient.navn(personIdent)
-        val pdf = pdfGenClient.createForhandsvarselPdf(
-            callId,
-            ForhandsvarselPdfDTO.create(
-                mottakerNavn = personNavn,
-                mottakerFodselsnummer = personIdent.value,
-                documentComponents = forhandsvarselDTO.document,
-            )
-        )
-
-        val vurdering: AktivitetskravVurdering = forhandsvarselDTO.toAktivitetskravVurdering(veilederIdent)
-        val updatedAktivitetskrav = aktivitetskrav.vurder(aktivitetskravVurdering = vurdering)
-        val forhandsvarsel = AktivitetskravVarsel.create(forhandsvarselDTO.document)
-
-        val nyttForhandsvarsel = aktivitetskravVarselRepository.create(
-            aktivitetskrav = updatedAktivitetskrav,
-            varsel = forhandsvarsel,
-            pdf = pdf,
-        )
-
-        aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
-            aktivitetskrav = updatedAktivitetskrav
-        )
-
-        return nyttForhandsvarsel.toAktivitetkravVarsel()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
@@ -1,0 +1,96 @@
+package no.nav.syfo.aktivitetskrav
+
+import no.nav.syfo.aktivitetskrav.api.ForhandsvarselDTO
+import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
+import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVarsel
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
+import no.nav.syfo.aktivitetskrav.domain.vurder
+import no.nav.syfo.aktivitetskrav.kafka.*
+import no.nav.syfo.client.krr.KRRClient
+import no.nav.syfo.client.pdfgen.ForhandsvarselPdfDTO
+import no.nav.syfo.client.pdfgen.PdfGenClient
+import no.nav.syfo.client.pdl.PdlClient
+import no.nav.syfo.domain.PersonIdent
+import java.util.UUID
+
+class AktivitetskravVarselService(
+    private val aktivitetskravVarselRepository: AktivitetskravVarselRepository,
+    private val aktivitetskravVurderingProducer: AktivitetskravVurderingProducer,
+    private val arbeidstakervarselProducer: ArbeidstakervarselProducer,
+    private val aktivitetskravVarselProducer: AktivitetskravVarselProducer,
+    private val pdfGenClient: PdfGenClient,
+    private val pdlClient: PdlClient,
+    private val krrClient: KRRClient,
+) {
+    fun getIkkeJournalforte(): List<Triple<PersonIdent, AktivitetskravVarsel, ByteArray>> {
+        return aktivitetskravVarselRepository.getIkkeJournalforte()
+            .map { Triple(it.first, it.second.toAktivitetkravVarsel(), it.third) }
+    }
+
+    fun getIkkePubliserte(): List<Triple<PersonIdent, AktivitetskravVarsel, UUID>> {
+        return aktivitetskravVarselRepository.getIkkePubliserte().map { Triple(it.first, it.second.toAktivitetkravVarsel(), it.third) }
+    }
+
+    fun publiser(varsel: AktivitetskravVarsel, personIdent: PersonIdent, aktivitetskravUuid: UUID) {
+        aktivitetskravVarselProducer.sendAktivitetskravVarsel(
+            personIdent = personIdent,
+            aktivitetskravUuid = aktivitetskravUuid,
+            varsel = varsel,
+        )
+        // TODO: Koden under kan fjernes når eSyfo konsumerer varselet over og sender til esyfovarsel
+        arbeidstakervarselProducer.sendArbeidstakervarsel(
+            varselHendelse = ArbeidstakerHendelse(
+                type = HendelseType.SM_FORHANDSVARSEL_STANS,
+                arbeidstakerFnr = personIdent.value,
+                data = VarselData(
+                    journalpost = VarselDataJournalpost(
+                        uuid = varsel.uuid.toString(),
+                        id = varsel.journalpostId,
+                    ),
+                ),
+                orgnummer = null,
+            )
+        )
+        aktivitetskravVarselRepository.setPublished(varsel)
+    }
+
+    fun setJournalfort(varsel: AktivitetskravVarsel, journalpostId: String) {
+        aktivitetskravVarselRepository.updateJournalpostId(
+            varsel = varsel,
+            journalpostId = journalpostId,
+        )
+    }
+
+    suspend fun sendForhandsvarsel(
+        aktivitetskrav: Aktivitetskrav,
+        veilederIdent: String,
+        personIdent: PersonIdent,
+        forhandsvarselDTO: ForhandsvarselDTO,
+        callId: String,
+    ): AktivitetskravVarsel {
+        val personNavn = pdlClient.navn(personIdent)
+        val pdf = pdfGenClient.createForhandsvarselPdf(
+            callId,
+            ForhandsvarselPdfDTO.create(
+                mottakerNavn = personNavn,
+                mottakerFodselsnummer = personIdent.value,
+                documentComponents = forhandsvarselDTO.document,
+            )
+        )
+
+        val vurdering: AktivitetskravVurdering = forhandsvarselDTO.toAktivitetskravVurdering(veilederIdent)
+        val updatedAktivitetskrav = aktivitetskrav.vurder(aktivitetskravVurdering = vurdering)
+        val forhandsvarsel = AktivitetskravVarsel.create(forhandsvarselDTO.document)
+
+        val nyttForhandsvarsel = aktivitetskravVarselRepository.create(
+            aktivitetskrav = updatedAktivitetskrav,
+            varsel = forhandsvarsel,
+            pdf = pdf,
+        )
+
+        aktivitetskravVurderingProducer.sendAktivitetskravVurdering(aktivitetskrav = updatedAktivitetskrav)
+
+        return nyttForhandsvarsel.toAktivitetkravVarsel()
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
@@ -29,7 +29,8 @@ class AktivitetskravVarselService(
     }
 
     fun getIkkePubliserte(): List<Triple<PersonIdent, AktivitetskravVarsel, UUID>> {
-        return aktivitetskravVarselRepository.getIkkePubliserte().map { Triple(it.first, it.second.toAktivitetkravVarsel(), it.third) }
+        return aktivitetskravVarselRepository.getIkkePubliserte()
+            .map { Triple(it.first, it.second.toAktivitetkravVarsel(), it.third) }
     }
 
     fun publiser(varsel: AktivitetskravVarsel, personIdent: PersonIdent, aktivitetskravUuid: UUID) {

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -6,6 +6,7 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.domain.toResponseDTOList
 import no.nav.syfo.application.api.VeilederTilgangskontrollPlugin
@@ -28,6 +29,7 @@ private const val API_ACTION = "access aktivitetskrav for person"
 fun Route.registerAktivitetskravApi(
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
     aktivitetskravService: AktivitetskravService,
+    aktivitetskravVarselService: AktivitetskravVarselService,
 ) {
     route(aktivitetskravApiBasePath) {
         install(VeilederTilgangskontrollPlugin) {
@@ -97,7 +99,7 @@ fun Route.registerAktivitetskravApi(
                 throw IllegalArgumentException("Failed to create forhandsvarsel: aktivitetskrav is not in a valid state")
             }
 
-            val forhandsvarsel = aktivitetskravService.sendForhandsvarsel(
+            val forhandsvarsel = aktivitetskravVarselService.sendForhandsvarsel(
                 aktivitetskrav = aktivitetskrav,
                 veilederIdent = call.getNAVIdent(),
                 personIdent = call.personIdent(),

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjob.kt
@@ -1,16 +1,13 @@
 package no.nav.syfo.aktivitetskrav.cronjob
 
 import net.logstash.logback.argument.StructuredArguments
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
-import no.nav.syfo.aktivitetskrav.kafka.*
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.application.cronjob.Cronjob
 import no.nav.syfo.application.cronjob.CronjobResult
 import org.slf4j.LoggerFactory
 
 class PubliserAktivitetskravVarselCronjob(
-    private val aktivitetskravVarselRepository: AktivitetskravVarselRepository,
-    private val arbeidstakervarselProducer: ArbeidstakervarselProducer,
-    private val aktivitetskravVarselProducer: AktivitetskravVarselProducer,
+    private val aktivitetskravVarselService: AktivitetskravVarselService,
 ) : Cronjob {
     override val initialDelayMinutes: Long = 7
     override val intervalDelayMinutes: Long = 10
@@ -26,29 +23,13 @@ class PubliserAktivitetskravVarselCronjob(
 
     fun runJob(): CronjobResult {
         val result = CronjobResult()
-        aktivitetskravVarselRepository.getIkkePubliserte().forEach { (personIdent, pAktivitetskravVarsel, aktivitetskravUuid) ->
+        aktivitetskravVarselService.getIkkePubliserte().forEach { (personIdent, varsel, aktivitetskravUuid) ->
             try {
-                val varsel = pAktivitetskravVarsel.toAktivitetkravVarsel()
-                aktivitetskravVarselProducer.sendAktivitetskravVarsel(
+                aktivitetskravVarselService.publiser(
                     personIdent = personIdent,
                     aktivitetskravUuid = aktivitetskravUuid,
                     varsel = varsel,
                 )
-                // TODO: Koden under kan fjernes når eSyfo konsumerer varselet over og sender til esyfovarsel
-                arbeidstakervarselProducer.sendArbeidstakervarsel(
-                    varselHendelse = ArbeidstakerHendelse(
-                        type = HendelseType.SM_FORHANDSVARSEL_STANS,
-                        arbeidstakerFnr = personIdent.value,
-                        data = VarselData(
-                            journalpost = VarselDataJournalpost(
-                                uuid = varsel.uuid.toString(),
-                                id = varsel.journalpostId,
-                            ),
-                        ),
-                        orgnummer = null,
-                    )
-                )
-                aktivitetskravVarselRepository.setPublished(varsel)
                 result.updated++
             } catch (e: Exception) {
                 log.error("Exception caught while attempting publisering of aktivitetskrav-varsel", e)

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -4,6 +4,7 @@ import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.aktivitetskrav.api.registerAktivitetskravApi
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
@@ -19,6 +20,7 @@ fun Application.apiModule(
     environment: Environment,
     wellKnownInternalAzureAD: WellKnown,
     aktivitetskravService: AktivitetskravService,
+    aktivitetskravVarselService: AktivitetskravVarselService,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
 ) {
     installMetrics()
@@ -45,6 +47,7 @@ fun Application.apiModule(
             registerAktivitetskravApi(
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
                 aktivitetskravService = aktivitetskravService,
+                aktivitetskravVarselService = aktivitetskravVarselService,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
@@ -1,27 +1,21 @@
 package no.nav.syfo.application.cronjob
 
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.aktivitetskrav.cronjob.*
-import no.nav.syfo.aktivitetskrav.kafka.KafkaArbeidstakervarselSerializer
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
-import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVarselProducer
 import no.nav.syfo.application.*
 import no.nav.syfo.application.database.DatabaseInterface
-import no.nav.syfo.application.kafka.kafkaAivenProducerConfig
-import no.nav.syfo.aktivitetskrav.kafka.ArbeidstakervarselProducer
-import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVarselSerializer
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.dokarkiv.DokarkivClient
 import no.nav.syfo.client.leaderelection.LeaderPodClient
 import no.nav.syfo.client.pdl.PdlClient
-import org.apache.kafka.clients.producer.KafkaProducer
 
 fun launchCronjobModule(
     applicationState: ApplicationState,
     environment: Environment,
     database: DatabaseInterface,
     aktivitetskravService: AktivitetskravService,
-    aktivitetskravVarselRepository: AktivitetskravVarselRepository,
+    aktivitetskravVarselService: AktivitetskravVarselService,
     pdlClient: PdlClient,
     azureAdClient: AzureAdClient,
 ) {
@@ -54,30 +48,14 @@ fun launchCronjobModule(
         dokarkivEnvironment = environment.clients.dokarkiv,
     )
     val journalforAktivitetskravVarselCronjob = JournalforAktivitetskravVarselCronjob(
-        aktivitetskravVarselRepository = aktivitetskravVarselRepository,
+        aktivitetskravVarselService = aktivitetskravVarselService,
         dokarkivClient = dokarkivClient,
         pdlClient = pdlClient
     )
     cronjobs.add(journalforAktivitetskravVarselCronjob)
 
-    val arbeidstakervarselProducer = ArbeidstakervarselProducer(
-        kafkaArbeidstakervarselProducer = KafkaProducer(
-            kafkaAivenProducerConfig<KafkaArbeidstakervarselSerializer>(
-                kafkaEnvironment = environment.kafka,
-            )
-        )
-    )
-    val aktivitetskravVarselProducer = AktivitetskravVarselProducer(
-        kafkaProducer = KafkaProducer(
-            kafkaAivenProducerConfig<KafkaAktivitetskravVarselSerializer>(
-                kafkaEnvironment = environment.kafka,
-            )
-        )
-    )
     val publiserAktivitetskravVarselCronjob = PubliserAktivitetskravVarselCronjob(
-        aktivitetskravVarselRepository = aktivitetskravVarselRepository,
-        arbeidstakervarselProducer = arbeidstakervarselProducer,
-        aktivitetskravVarselProducer = aktivitetskravVarselProducer,
+        aktivitetskravVarselService = aktivitetskravVarselService,
     )
     cronjobs.add(publiserAktivitetskravVarselCronjob)
 

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -6,7 +6,6 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskravVurderinger
 import no.nav.syfo.aktivitetskrav.domain.*
@@ -57,7 +56,6 @@ class AktivitetskravApiSpek : Spek({
             val externalMockEnvironment = ExternalMockEnvironment.instance
             val database = externalMockEnvironment.database
             val kafkaProducer = mockk<KafkaProducer<String, KafkaAktivitetskravVurdering>>()
-            val aktivitetskravVarselRepository = AktivitetskravVarselRepository(database = database)
 
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
@@ -69,10 +67,6 @@ class AktivitetskravApiSpek : Spek({
                 aktivitetskravVurderingProducer = mockk(relaxed = true),
                 database = database,
                 arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
-                aktivitetskravVarselRepository = aktivitetskravVarselRepository,
-                pdfGenClient = externalMockEnvironment.pdfgenClient,
-                pdlClient = externalMockEnvironment.pdlClient,
-                krrClient = externalMockEnvironment.krrClient,
             )
 
             beforeEachTest {

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravAutomatiskOppfyltCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravAutomatiskOppfyltCronjobSpek.kt
@@ -4,7 +4,6 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
@@ -39,10 +38,6 @@ class AktivitetskravAutomatiskOppfyltCronjobSpek : Spek({
             database = database,
             aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
             arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
-            aktivitetskravVarselRepository = AktivitetskravVarselRepository(database = database),
-            pdfGenClient = externalMockEnvironment.pdfgenClient,
-            pdlClient = externalMockEnvironment.pdlClient,
-            krrClient = externalMockEnvironment.krrClient,
         )
 
         val aktivitetskravAutomatiskOppfyltCronjob = AktivitetskravAutomatiskOppfyltCronjob(

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravNyCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravNyCronjobSpek.kt
@@ -4,7 +4,6 @@ import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
@@ -39,10 +38,6 @@ class AktivitetskravNyCronjobSpek : Spek({
             database = database,
             aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
             arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
-            aktivitetskravVarselRepository = AktivitetskravVarselRepository(database = database),
-            pdfGenClient = externalMockEnvironment.pdfgenClient,
-            pdlClient = externalMockEnvironment.pdlClient,
-            krrClient = externalMockEnvironment.krrClient,
         )
 
         val aktivitetskravNyCronjob = AktivitetskravNyCronjob(

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVarsel
@@ -56,10 +57,20 @@ class JournalforAktivitetskravVarselCronjobSpek : Spek({
         val aktivitetskravVarselRepository = AktivitetskravVarselRepository(database = database)
         val dokarkivClient = mockk<DokarkivClient>()
 
-        val journalforAktivitetskravVarselCronjob = JournalforAktivitetskravVarselCronjob(
+        val aktivitetskravVarselService = AktivitetskravVarselService(
             aktivitetskravVarselRepository = aktivitetskravVarselRepository,
+            aktivitetskravVurderingProducer = mockk(),
+            arbeidstakervarselProducer = mockk(),
+            aktivitetskravVarselProducer = mockk(),
+            pdfGenClient = externalMockEnvironment.pdfgenClient,
+            pdlClient = externalMockEnvironment.pdlClient,
+            krrClient = externalMockEnvironment.krrClient,
+        )
+
+        val journalforAktivitetskravVarselCronjob = JournalforAktivitetskravVarselCronjob(
             dokarkivClient = dokarkivClient,
             pdlClient = externalMockEnvironment.pdlClient,
+            aktivitetskravVarselService = aktivitetskravVarselService,
         )
 
         fun createForhandsvarsel(aktivitetskrav: Aktivitetskrav, pdf: ByteArray): AktivitetskravVarsel {

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
@@ -3,12 +3,10 @@ package no.nav.syfo.aktivitetskrav.cronjob
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.*
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
 import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVurdering
-import no.nav.syfo.client.pdfgen.PdfGenClient
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.createAktivitetskrav
@@ -34,10 +32,6 @@ class OutdatedAktivitetskravCronjobSpek : Spek({
         database = database,
         aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(kafkaProducerAktivitetskravVurdering = kafkaProducer),
         arenaCutoff = arenaCutoff,
-        aktivitetskravVarselRepository = AktivitetskravVarselRepository(database = database),
-        pdfGenClient = mockk<PdfGenClient>(),
-        pdlClient = externalMockEnvironment.pdlClient,
-        krrClient = externalMockEnvironment.krrClient,
     )
     val outdatedAktivitetskravCronjob = OutdatedAktivitetskravCronjob(
         outdatedCutoff = outdatedCutoff,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjobSpek.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.aktivitetskrav.cronjob
 import io.ktor.server.testing.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVarsel
@@ -49,11 +50,18 @@ class PubliserAktivitetskravVarselCronjobSpek : Spek({
         val aktivitetskravVarselProducer = AktivitetskravVarselProducer(
             kafkaProducer = aktivitetskravVarselKafkaProducer,
         )
-
-        val publiserAktivitetskravVarselCronjob = PubliserAktivitetskravVarselCronjob(
+        val aktivitetskravVarselService = AktivitetskravVarselService(
             aktivitetskravVarselRepository = aktivitetskravVarselRepository,
+            aktivitetskravVurderingProducer = mockk(),
             arbeidstakervarselProducer = arbeidstakerVarselProducer,
             aktivitetskravVarselProducer = aktivitetskravVarselProducer,
+            pdfGenClient = externalMockEnvironment.pdfgenClient,
+            pdlClient = externalMockEnvironment.pdlClient,
+            krrClient = externalMockEnvironment.krrClient,
+        )
+
+        val publiserAktivitetskravVarselCronjob = PubliserAktivitetskravVarselCronjob(
+            aktivitetskravVarselService = aktivitetskravVarselService,
         )
 
         fun createForhandsvarsel(

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.oppfolgingstilfelle.kafka
 import io.ktor.server.testing.*
 import io.mockk.*
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
-import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.database.getAktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
@@ -48,10 +47,6 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
             aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
             database = database,
             arenaCutoff = arenaCutoff,
-            aktivitetskravVarselRepository = AktivitetskravVarselRepository(database = database),
-            pdfGenClient = externalMockEnvironment.pdfgenClient,
-            pdlClient = externalMockEnvironment.pdlClient,
-            krrClient = externalMockEnvironment.krrClient,
         )
         val kafkaOppfolgingstilfellePersonService = KafkaOppfolgingstilfellePersonService(
             database = database,

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -1,7 +1,9 @@
 package no.nav.syfo.testhelper
 
 import io.ktor.server.application.*
+import io.mockk.mockk
 import no.nav.syfo.aktivitetskrav.AktivitetskravService
+import no.nav.syfo.aktivitetskrav.AktivitetskravVarselService
 import no.nav.syfo.aktivitetskrav.database.AktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
 import no.nav.syfo.application.api.apiModule
@@ -15,12 +17,17 @@ fun Application.testApiModule(
         aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
         database = externalMockEnvironment.database,
         arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
+    )
+    val aktivitetskravVarselService = AktivitetskravVarselService(
         pdfGenClient = externalMockEnvironment.pdfgenClient,
         aktivitetskravVarselRepository = AktivitetskravVarselRepository(
             database = externalMockEnvironment.database
         ),
         pdlClient = externalMockEnvironment.pdlClient,
         krrClient = externalMockEnvironment.krrClient,
+        arbeidstakervarselProducer = mockk(),
+        aktivitetskravVarselProducer = mockk(),
+        aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
     )
     val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
         azureAdClient = externalMockEnvironment.azureAdClient,
@@ -33,6 +40,7 @@ fun Application.testApiModule(
         environment = externalMockEnvironment.environment,
         wellKnownInternalAzureAD = externalMockEnvironment.wellKnownInternalAzureAD,
         aktivitetskravService = aktivitetskravService,
+        aktivitetskravVarselService = aktivitetskravVarselService,
         veilederTilgangskontrollClient = veilederTilgangskontrollClient,
     )
 }


### PR DESCRIPTION
Flyttet varsel-relaterte fra `AktivitetskravService` til `AktivitetskravVarselService` og bruker samtidig denne fra cronjobbene.