### PR TITLE
Add varsel to responsedto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
@@ -63,6 +63,10 @@ class AktivitetskravVarselService(
         )
     }
 
+    fun getVarsel(vurderingUuid: UUID): AktivitetskravVarsel? {
+        return aktivitetskravVarselRepository.getVarselForVurdering(vurderingUuid = vurderingUuid)?.toAktivitetkravVarsel()
+    }
+
     suspend fun sendForhandsvarsel(
         aktivitetskrav: Aktivitetskrav,
         veilederIdent: String,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -43,11 +43,11 @@ fun Route.registerAktivitetskravApi(
                 personIdent = personIdent,
             )
             val responseDTOList = aktivitetskravAfterCutoff.map { aktivitetskrav ->
-                val vurderingResponseDTOS = aktivitetskrav.vurderinger.map { vurdering ->
+                val vurderingResponseDTOs = aktivitetskrav.vurderinger.map { vurdering ->
                     val varsel = aktivitetskravVarselService.getVarsel(vurdering.uuid)
                     vurdering.toVurderingResponseDto(varsel)
                 }
-                aktivitetskrav.toResponseDTO(vurderingResponseDTOS)
+                aktivitetskrav.toResponseDTO(vurderingResponseDTOs)
             }
 
             call.respond(responseDTOList)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
@@ -27,5 +27,5 @@ data class AktivitetskravVurderingResponseDTO(
 data class VarselResponseDTO(
     val uuid: String,
     val createdAt: LocalDateTime,
-    // TODO: svarfrist
+    val svarFrist: LocalDate,
 )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
@@ -21,4 +21,11 @@ data class AktivitetskravVurderingResponseDTO(
     val beskrivelse: String?,
     val arsaker: List<VurderingArsak>,
     val frist: LocalDate?,
+    val varsel: VarselResponseDTO?
+)
+
+data class VarselResponseDTO(
+    val uuid: String,
+    val createdAt: LocalDateTime,
+    // TODO: svarfrist
 )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -56,6 +56,8 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
 
     fun setPublished(varsel: AktivitetskravVarsel) =
         database.setPublished(varsel)
+
+    fun getVarselForVurdering(vurderingUuid: UUID) = database.getVarselForVurdering(vurderingUuid = vurderingUuid)
 }
 
 private const val queryCreateAktivitetskravVarsel =
@@ -209,6 +211,23 @@ private fun DatabaseInterface.setPublished(varsel: AktivitetskravVarsel) {
             }
         }
         connection.commit()
+    }
+}
+
+private const val queryGetVarselWithVurderingId = """
+    SELECT av.* 
+    FROM aktivitetskrav_varsel av 
+    INNER JOIN aktivitetskrav_vurdering avu
+    ON av.aktivitetskrav_vurdering_id = avu.id
+    WHERE avu.uuid = ?
+"""
+
+private fun DatabaseInterface.getVarselForVurdering(vurderingUuid: UUID): PAktivitetskravVarsel? {
+    return this.connection.use { connection ->
+        connection.prepareStatement(queryGetVarselWithVurderingId).use {
+            it.setString(1, vurderingUuid.toString())
+            it.executeQuery().toList { toPAktivitetskravVarsel() }
+        }.firstOrNull()
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -214,7 +214,7 @@ private fun DatabaseInterface.setPublished(varsel: AktivitetskravVarsel) {
     }
 }
 
-private const val queryGetVarselWithVurderingId = """
+private const val queryGetVarselWithVurderingUuid = """
     SELECT av.* 
     FROM aktivitetskrav_varsel av 
     INNER JOIN aktivitetskrav_vurdering avu
@@ -224,7 +224,7 @@ private const val queryGetVarselWithVurderingId = """
 
 private fun DatabaseInterface.getVarselForVurdering(vurderingUuid: UUID): PAktivitetskravVarsel? {
     return this.connection.use { connection ->
-        connection.prepareStatement(queryGetVarselWithVurderingId).use {
+        connection.prepareStatement(queryGetVarselWithVurderingUuid).use {
             it.setString(1, vurderingUuid.toString())
             it.executeQuery().toList { toPAktivitetskravVarsel() }
         }.firstOrNull()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.aktivitetskrav.domain
 
 import no.nav.syfo.aktivitetskrav.api.AktivitetskravResponseDTO
+import no.nav.syfo.aktivitetskrav.api.AktivitetskravVurderingResponseDTO
 import no.nav.syfo.aktivitetskrav.database.PAktivitetskrav
 import no.nav.syfo.aktivitetskrav.kafka.KafkaAktivitetskravVurdering
 import no.nav.syfo.domain.PersonIdent
@@ -120,15 +121,14 @@ fun Aktivitetskrav.isAutomatiskOppfylt(): Boolean =
 
 fun Aktivitetskrav.isNy(): Boolean = this.status == AktivitetskravStatus.NY
 
-fun List<Aktivitetskrav>.toResponseDTOList() = this.map {
+fun Aktivitetskrav.toResponseDTO(vurderinger: List<AktivitetskravVurderingResponseDTO>): AktivitetskravResponseDTO =
     AktivitetskravResponseDTO(
-        uuid = it.uuid.toString(),
-        createdAt = it.createdAt.toLocalDateTime(),
-        status = it.status,
-        stoppunktAt = it.stoppunktAt,
-        vurderinger = it.vurderinger.toVurderingResponseDTOs()
+        uuid = uuid.toString(),
+        createdAt = createdAt.toLocalDateTime(),
+        status = status,
+        stoppunktAt = stoppunktAt,
+        vurderinger = vurderinger
     )
-}
 
 internal fun Aktivitetskrav.shouldUpdateStoppunkt(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean {
     val updatedStoppunktDato = Aktivitetskrav.stoppunktDato(oppfolgingstilfelle.tilfelleStart)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
@@ -39,6 +39,7 @@ data class AktivitetskravVarsel internal constructor(
 
     fun toVarselResponseDTO() = VarselResponseDTO(
         uuid = this.uuid.toString(),
-        createdAt = this.createdAt.toLocalDateTime()
+        createdAt = this.createdAt.toLocalDateTime(),
+        svarFrist = this.createdAt.toLocalDate().plusWeeks(3)
     )
 }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.aktivitetskrav.domain
 
 import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.aktivitetskrav.api.VarselResponseDTO
 import no.nav.syfo.util.nowUTC
 import java.time.OffsetDateTime
 import java.util.*
@@ -35,4 +36,9 @@ data class AktivitetskravVarsel internal constructor(
             isPublished = published,
         )
     }
+
+    fun toVarselResponseDTO() = VarselResponseDTO(
+        uuid = this.uuid.toString(),
+        createdAt = this.createdAt.toLocalDateTime()
+    )
 }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVurdering.kt
@@ -93,10 +93,7 @@ data class AktivitetskravVurdering private constructor(
 
 fun AktivitetskravVurdering.arsakerToString() = this.arsaker.joinToString(",")
 
-fun List<AktivitetskravVurdering>.toVurderingResponseDTOs(): List<AktivitetskravVurderingResponseDTO> =
-    this.map { it.toVurderingResponseDto() }
-
-fun AktivitetskravVurdering.toVurderingResponseDto(): AktivitetskravVurderingResponseDTO =
+fun AktivitetskravVurdering.toVurderingResponseDto(varsel: AktivitetskravVarsel?): AktivitetskravVurderingResponseDTO =
     AktivitetskravVurderingResponseDTO(
         uuid = this.uuid.toString(),
         createdAt = this.createdAt.toLocalDateTime(),
@@ -105,4 +102,5 @@ fun AktivitetskravVurdering.toVurderingResponseDto(): AktivitetskravVurderingRes
         beskrivelse = this.beskrivelse,
         arsaker = this.arsaker,
         frist = this.frist,
+        varsel = varsel?.toVarselResponseDTO()
     )

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -399,7 +399,9 @@ class AktivitetskravApiSpek : Spek({
                             val responseDTOList =
                                 objectMapper.readValue<List<AktivitetskravResponseDTO>>(response.content!!)
                             val aktivitetskravResponseDTO = responseDTOList.first()
-                            aktivitetskravResponseDTO.vurderinger.first().varsel.shouldNotBeNull()
+                            val varselResponseDTO = aktivitetskravResponseDTO.vurderinger.first().varsel
+                            varselResponseDTO.shouldNotBeNull()
+                            varselResponseDTO.svarFrist shouldBeEqualTo varselResponseDTO.createdAt.toLocalDate().plusWeeks(3)
                         }
                     }
                 }


### PR DESCRIPTION
Tanken er at APIet også må returnere evt varsel knyttet til en vurdering slik at vi kan vise svar-fristen på forhåndsvarselet i modia:
![image](https://github.com/navikt/isaktivitetskrav/assets/79838644/9a85f7cf-b352-41d0-9bde-bee0996fba64)
Pdd hentes denne fra vurderingen, men vi ønsker å heller lagre dette i nytt svar-frist-felt på varselet.