### PR TITLE
Fix deploy of kafka topic to nais cluster

### DIFF
--- a/.nais/kafka/aktivitetskrav-expired-varsel.yaml
+++ b/.nais/kafka/aktivitetskrav-expired-varsel.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     team: teamsykefravr
 spec:
-  pool: { { kafkaPool } }
+  pool: {{ kafkaPool }}
   config:
     cleanupPolicy: delete
     minimumInSyncReplicas: 1


### PR DESCRIPTION
Fixes earlier fail of deploy. `{ { kafkaPool } }` is not the same as `{{ kafkaPool }}`🤝