### PR TITLE
IS-1649: Set expired date to same as svarfrist

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -95,7 +95,7 @@ private object Queries {
             SELECT *
             FROM aktivitetskrav_varsel
             WHERE expired_varsel_published_at IS NULL
-                AND svarfrist <= (NOW() - INTERVAL '1 weeks')
+                AND svarfrist <= NOW()
         """
 
     const val setExpiredVarselPublishedAt =
@@ -129,7 +129,7 @@ private fun Connection.createAktivitetskravVarsel(
     val varsler = this.prepareStatement(queryCreateAktivitetskravVarsel).use {
         it.setString(1, varsel.uuid.toString())
         it.setObject(2, varsel.createdAt)
-        it.setObject(3, nowUTC())
+        it.setObject(3, varsel.createdAt)
         it.setInt(4, vurderingId)
         it.setObject(5, mapper.writeValueAsString(varsel.document))
         it.setNull(6, Types.VARCHAR)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
@@ -107,9 +107,12 @@ class AktivitetskravRepositorySpek : Spek({
 
                     val expiredVarsler = runBlocking { aktivitetskravVarselRepository.getExpiredVarsler() }
 
-                    expiredVarsler.size shouldBeEqualTo 2
+                    expiredVarsler.size shouldBeEqualTo 3
                     expiredVarsler.any {
-                        it.svarfrist == LocalDate.now().minusWeeks(1).minusDays(1)
+                        it.svarfrist == LocalDate.now()
+                    } shouldBe true
+                    expiredVarsler.any {
+                        it.svarfrist == LocalDate.now().minusDays(1)
                     } shouldBe true
                     expiredVarsler.any {
                         it.svarfrist == LocalDate.now().minusWeeks(1)

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
@@ -92,10 +92,10 @@ fun createNAktivitetskrav(
 fun createVarsler(): List<AktivitetskravVarsel> {
     val document = generateDocumentComponentDTO(fritekst = "Et test varsel")
     return listOf(
-        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1).minusDays(1)),
         AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusDays(6)),
+        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusDays(1)),
         AktivitetskravVarsel.create(document, svarfrist = LocalDate.now()),
         AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().plusDays(1)),
+        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().plusWeeks(1)),
     )
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Svarfrist for innbyggere og dagen veiledere skal få opp oppgave i oversikten skal begge være 3 uker. Denne PR'en endrer at vi sender utgåtte varsler til veiledere `svarfrist + 1 uke` og sender heller utgåtte varsler til veildere på samme tid som `svarfrist`