### PR TITLE
IS-1633: Add migration script to delete vurdering

### DIFF
--- a/src/main/resources/db/migration/V3_3__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V3_3__delete_wrong_vurdering.sql
@@ -1,0 +1,3 @@
+DELETE
+FROM aktivitetskrav_vurdering
+WHERE uuid = '1cd52097-1385-4216-8365-4db94c2fc123';


### PR DESCRIPTION
Sletter feil vurdering. Den forrige vurderingen var også unntak og tror derfor det blir riktig å bare slette vurderingen uten å endre status for `aktivitetskrav`.