### PR TITLE
IS-1581: Remove toggle for expired varsel

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -102,8 +102,6 @@ spec:
       value: "2023-06-01"
     - name: OUTDATED_AKTIVITETSKRAV_CRONJOB_ENABLED
       value: "true"
-    - name: IS_PUBLISH_EXPIRED_VARSEL_CRONJOB_ENABLED
-      value: "true"
     - name: PUBLISH_EXPIRED_VARSEL_CRONJOB_INTERVAL_DELAY_MINUTES
       value: "10"
 

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -102,7 +102,5 @@ spec:
       value: "2023-06-01"
     - name: OUTDATED_AKTIVITETSKRAV_CRONJOB_ENABLED
       value: "true"
-    - name: IS_PUBLISH_EXPIRED_VARSEL_CRONJOB_ENABLED
-      value: "false"
     - name: PUBLISH_EXPIRED_VARSEL_CRONJOB_INTERVAL_DELAY_MINUTES
       value: "360" # Hver 6. time, 60*6

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -45,7 +45,6 @@ data class Environment(
     val arenaCutoff: LocalDate = LocalDate.parse(getEnvVar("ARENA_CUTOFF")),
     val automatiskOppfyltCronJobEnabled: Boolean = getEnvVar("AUTOMATISK_OPPFYLT_CRONJOB_ENABLED").toBoolean(),
     val nyCronjobEnabled: Boolean = getEnvVar("NY_CRONJOB_ENABLED").toBoolean(),
-    val isPublishExpiredVarselCronjobEnabled: Boolean = getEnvVar("IS_PUBLISH_EXPIRED_VARSEL_CRONJOB_ENABLED").toBoolean(),
     val publishExpiredVarselCronjobIntervalDelayMinutes: Long = getEnvVar("PUBLISH_EXPIRED_VARSEL_CRONJOB_INTERVAL_DELAY_MINUTES").toLong(),
     val outdatedCutoff: LocalDate = LocalDate.parse(getEnvVar("OUTDATED_AKTIVITETSKRAV_CUTOFF")),
     val outdatedCronJobEnabled: Boolean = getEnvVar("OUTDATED_AKTIVITETSKRAV_CRONJOB_ENABLED").toBoolean(),

--- a/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cronjob/CronjobModule.kt
@@ -59,14 +59,12 @@ fun launchCronjobModule(
     )
     cronjobs.add(publiserAktivitetskravVarselCronjob)
 
-    if (environment.isPublishExpiredVarselCronjobEnabled) {
-        val publishExpiredVarslerCronJob =
-            PublishExpiredVarslerCronJob(
-                aktivitetskravVarselService = aktivitetskravVarselService,
-                intervalDelayMinutes = environment.publishExpiredVarselCronjobIntervalDelayMinutes
-            )
-        cronjobs.add(publishExpiredVarslerCronJob)
-    }
+    val publishExpiredVarslerCronJob =
+        PublishExpiredVarslerCronJob(
+            aktivitetskravVarselService = aktivitetskravVarselService,
+            intervalDelayMinutes = environment.publishExpiredVarselCronjobIntervalDelayMinutes
+        )
+    cronjobs.add(publishExpiredVarslerCronJob)
 
     if (environment.outdatedCronJobEnabled) {
         val outdatedAktivitetskravCronjob = OutdatedAktivitetskravCronjob(

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -66,7 +66,6 @@ fun testEnvironment() = Environment(
     electorPath = "electorPath",
     automatiskOppfyltCronJobEnabled = true,
     nyCronjobEnabled = true,
-    isPublishExpiredVarselCronjobEnabled = true,
     publishExpiredVarselCronjobIntervalDelayMinutes = 10,
     outdatedCutoff = LocalDate.now().minusMonths(6),
     outdatedCronJobEnabled = true,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Slår på i prod/fjerner toggle for publisering av utgåtte varsler, som `ispersonoppgave` bruker for å lage `vurder_stans`-oppgaver.