### PR TITLE
Give aktivitetskrav-backend permission to read from 'teamsykefravr.ak…

### DIFF
--- a/.nais/kafka/aktivitetskrav.yaml
+++ b/.nais/kafka/aktivitetskrav.yaml
@@ -34,3 +34,6 @@ spec:
     - team: teamsykefravr
       application: iskafkamanager
       access: read
+    - team: team-esyfo
+      application: aktivitetskrav-backend
+      access: read


### PR DESCRIPTION
…tivtetskrav-vurdering'-topic

### Hva har blitt lagt til✨🌈

Gir aktivtetskrav-backend tilgang til 'teamsykefravr.aktivtetskrav-vurdering' for å lese status
som vi trenger for å avgjøre om aktivetskrav varsel skal vises.