### PR TITLE
IS-1669: Add filtering out handled varsler + tests

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -110,12 +110,12 @@ class AktivitetskravService(
             Aktivitetskrav.fromVurdering(personIdent = personIdent, vurdering = aktivitetskravVurdering)
 
         database.connection.use { connection ->
-            val aktivitetskravId = connection.createAktivitetskrav(
+            val pAktivitetskrav = connection.createAktivitetskrav(
                 aktivitetskrav = aktivitetskrav,
                 referanseTilfelleBitUUID = null
             )
             connection.createAktivitetskravVurdering(
-                aktivitetskravId = aktivitetskravId,
+                aktivitetskravId = pAktivitetskrav.id,
                 aktivitetskravVurdering = aktivitetskravVurdering
             )
             connection.commit()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -100,7 +100,7 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
     companion object {
         private const val SELECT_EXPIRED_VARSLER =
             """
-            SELECT a.personident, a.uuid as aktivitetskrav_uuid, a.id as aktivitetskrav_id, varsel.*
+            SELECT a.personident, a.uuid as aktivitetskrav_uuid, varsel.*
             FROM aktivitetskrav_varsel varsel
                 INNER JOIN aktivitetskrav_vurdering vurdering
                     ON varsel.aktivitetskrav_vurdering_id = vurdering.id

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -112,7 +112,6 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
                     FROM aktivitetskrav_vurdering vurdering
                     WHERE vurdering.aktivitetskrav_id = a.id
                         AND vurdering.created_at > varsel.created_at
-                        AND varsel.created_at + (INTERVAL '3 weeks') > vurdering.created_at
                         AND vurdering.status IN ('UNNTAK', 'OPPFYLT', 'IKKE_AKTUELL')
                 )
             """

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -108,7 +108,7 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
             WHERE expired_varsel_published_at IS NULL
                 AND svarfrist <= NOW()
                 AND NOT EXISTS (
-                    SELECT a.id
+                    SELECT 1
                     FROM aktivitetskrav_vurdering vurdering
                     WHERE vurdering.aktivitetskrav_id = a.id
                         AND vurdering.created_at > varsel.created_at

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
@@ -22,13 +22,13 @@ const val queryCreateAktivitetskrav =
         stoppunkt_at,
         referanse_tilfelle_bit_uuid
     ) values (DEFAULT, ?, ?, ?, ?, ?, ?, ?)
-    RETURNING id
+    RETURNING *
     """
 
 fun Connection.createAktivitetskrav(
     aktivitetskrav: Aktivitetskrav,
     referanseTilfelleBitUUID: UUID?,
-): Int {
+): PAktivitetskrav {
     val idList = this.prepareStatement(queryCreateAktivitetskrav).use {
         it.setString(1, aktivitetskrav.uuid.toString())
         it.setObject(2, aktivitetskrav.createdAt)
@@ -37,7 +37,7 @@ fun Connection.createAktivitetskrav(
         it.setString(5, aktivitetskrav.status.name)
         it.setDate(6, Date.valueOf(aktivitetskrav.stoppunktAt))
         it.setString(7, referanseTilfelleBitUUID?.toString())
-        it.executeQuery().toList { getInt("id") }
+        it.executeQuery().toList { toPAktivitetskrav() }
     }
 
     if (idList.size != 1) {
@@ -60,13 +60,13 @@ const val queryCreateAktivitetskravVurdering =
         arsaker,
         frist
     ) values (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?)
-    RETURNING id
+    RETURNING *
     """
 
 fun Connection.createAktivitetskravVurdering(
     aktivitetskravId: Int,
     aktivitetskravVurdering: AktivitetskravVurdering,
-): Int {
+): PAktivitetskravVurdering {
     val idList = this.prepareStatement(queryCreateAktivitetskravVurdering).use {
         it.setString(1, aktivitetskravVurdering.uuid.toString())
         it.setInt(2, aktivitetskravId)
@@ -76,7 +76,7 @@ fun Connection.createAktivitetskravVurdering(
         it.setString(6, aktivitetskravVurdering.beskrivelse)
         it.setString(7, aktivitetskravVurdering.arsakerToString())
         it.setDate(8, aktivitetskravVurdering.frist?.let { frist -> Date.valueOf(frist) })
-        it.executeQuery().toList { getInt("id") }
+        it.executeQuery().toList { toPAktivitetskravVurdering() }
     }
 
     if (idList.size != 1) {

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
@@ -120,7 +120,7 @@ class AktivitetskravRepositorySpek : Spek({
 
                 it("Is not retrieving expired varsler which has OPPFYLT or UNNTAK status after they are created") {
                     val createdAktivitetskravList =
-                        createNAktivitetskrav(4)
+                        createNAktivitetskrav(5)
                             .map {
                                 val vurdering = AktivitetskravVurdering.create(
                                     status = AktivitetskravStatus.FORHANDSVARSEL,
@@ -137,7 +137,8 @@ class AktivitetskravRepositorySpek : Spek({
                         AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
                         AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
                         AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1))
+                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
+                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
                     )
                     for ((aktivitetkrav, varsel) in createdAktivitetskravList.zip(varsler)) {
                         aktivitetskravVarselRepository.create(
@@ -150,15 +151,22 @@ class AktivitetskravRepositorySpek : Spek({
                         createAktivitetskravOppfylt(createdAktivitetskravList[0])
                     val aktivitetskravUnntak =
                         createAktivitetskravUnntak(createdAktivitetskravList[1])
+                    val aktivitetskravIkkeAktuell =
+                        createAktivitetskravUnntak(createdAktivitetskravList[2])
                     val aktivitetskravAvvent =
-                        createAktivitetskravAvvent(createdAktivitetskravList[2])
+                        createAktivitetskravAvvent(createdAktivitetskravList[3])
 
                     database.connection.use { connection ->
                         val oppfyltId = connection.updateAktivitetskrav(aktivitetskravOppfylt)
                         val unntakId = connection.updateAktivitetskrav(aktivitetskravUnntak)
+                        val ikkeAktuellId = connection.updateAktivitetskrav(aktivitetskravIkkeAktuell)
                         val avventId = connection.updateAktivitetskrav(aktivitetskravAvvent)
                         connection.createAktivitetskravVurdering(oppfyltId, aktivitetskravOppfylt.vurderinger.first())
                         connection.createAktivitetskravVurdering(unntakId, aktivitetskravUnntak.vurderinger.first())
+                        connection.createAktivitetskravVurdering(
+                            ikkeAktuellId,
+                            aktivitetskravIkkeAktuell.vurderinger.first()
+                        )
                         connection.createAktivitetskravVurdering(avventId, aktivitetskravAvvent.vurderinger.first())
                         connection.commit()
                     }

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
@@ -133,13 +133,8 @@ class AktivitetskravRepositorySpek : Spek({
                                 database.createAktivitetskrav(updatedAktivitetskrav)
                                 updatedAktivitetskrav
                             }
-                    val varsler = listOf(
-                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-                        AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)),
-                    )
+                    val varsler =
+                        List(5) { AktivitetskravVarsel.create(document, svarfrist = LocalDate.now().minusWeeks(1)) }
                     for ((aktivitetkrav, varsel) in createdAktivitetskravList.zip(varsler)) {
                         aktivitetskravVarselRepository.create(
                             aktivitetskrav = aktivitetkrav,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
@@ -118,7 +118,7 @@ class AktivitetskravRepositorySpek : Spek({
                     } shouldBe true
                 }
 
-                it("Is not retrieving expired varsler which has OPPFYLT or UNNTAK status after they are created") {
+                it("Is not retrieving expired varsler which has OPPFYLT, UNNTAK or IKKE_AKTUELL status after they are created") {
                     val createdAktivitetskravList =
                         createNAktivitetskrav(5)
                             .map {

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestDatabase.kt
@@ -1,10 +1,7 @@
 package no.nav.syfo.testhelper
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
-import no.nav.syfo.aktivitetskrav.database.PAktivitetskravVarselPdf
-import no.nav.syfo.aktivitetskrav.database.PAktivitetskravVarsel
-import no.nav.syfo.aktivitetskrav.database.createAktivitetskrav
-import no.nav.syfo.aktivitetskrav.database.toPAktivitetskravVarsel
+import no.nav.syfo.aktivitetskrav.database.*
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.application.database.DatabaseInterface
 import no.nav.syfo.application.database.toList
@@ -88,14 +85,14 @@ fun DatabaseInterface.dropData() {
     }
 }
 
-fun DatabaseInterface.createAktivitetskrav(vararg aktivitetskrav: Aktivitetskrav) {
+fun DatabaseInterface.createAktivitetskrav(vararg aktivitetskrav: Aktivitetskrav): List<PAktivitetskrav> =
     this.connection.use { connection ->
-        aktivitetskrav.forEach {
+        val createdAktivitetskrav = aktivitetskrav.map {
             connection.createAktivitetskrav(aktivitetskrav = it, referanseTilfelleBitUUID = UUID.randomUUID())
         }
         connection.commit()
+        createdAktivitetskrav
     }
-}
 
 const val queryGetVarslerForPerson = """
     SELECT av.* 
@@ -120,7 +117,4 @@ class TestDatabaseNotResponding : DatabaseInterface {
 
     override val connection: Connection
         get() = throw Exception("Not working")
-
-    fun stop() {
-    }
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til å filtrere ut varsler som er "håndtert" når vi henter varsler som er utgått altså tidspunktet innbygger har å svare på varselet og når veileder får varsel opp i sin egen oversikt over "oppgaver".
- Legger også til en test som lager 3 forhåndsvarsler der man etterpå vurderer 2 av de til `OPPFYLT` of `UNNTAK`.

`Handled`/`Håndtert` = Når man som veileder mellom varselet har blitt laget og tiden før det har gått ut har satt en ny vurdering på aktivitetskravet som er `OPPFYLT` eller `UNNTAK`. Da har man håndtert det gjeldende varselet og de trenger ikke å få dette opp i sin oversikt.

- [x] Sjekk om `IKKE_AKTUELL` også burde være en vurdering som fører til at varselet blir håndtert