### PR TITLE
IS-1749: Add migration script for new column

### DIFF
--- a/src/main/resources/db/migration/V3_5__add_original_aktivitetskrav_uuid.sql
+++ b/src/main/resources/db/migration/V3_5__add_original_aktivitetskrav_uuid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE AKTIVITETSKRAV
+    ADD COLUMN previous_aktivitetskrav_uuid UUID;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til ny kolonne i `aktivietskrav` database som skal holde en uuid referanse til originaltilfellet av aktivitetskravet slik at vi har kontroll på hvilke vurderingsrunder som gjøres innenfor samme sykefraværstilfelle.
- Bare å komme med forslag til navn på denne kolonnen🙏