### PR TITLE
IS-1601: Send varsel-document in response for aktivitetskrav get-call

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
@@ -28,4 +28,5 @@ data class VarselResponseDTO(
     val uuid: String,
     val createdAt: LocalDateTime,
     val svarfrist: LocalDate,
+    val document: List<DocumentComponentDTO>,
 )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravVarsel.kt
@@ -50,6 +50,7 @@ data class AktivitetskravVarsel internal constructor(
         uuid = this.uuid.toString(),
         createdAt = this.createdAt.toLocalDateTime(),
         svarfrist = this.svarfrist,
+        document = this.document,
     )
 }
 

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -408,6 +408,7 @@ class AktivitetskravApiSpek : Spek({
                             varselResponseDTO.shouldNotBeNull()
                             varselResponseDTO.svarfrist shouldBeEqualTo varselResponseDTO.createdAt.toLocalDate()
                                 .plusWeeks(3)
+                            varselResponseDTO.document shouldBeEqualTo forhandsvarselDTO.document
                         }
                     }
                 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Under Historikk i aktivitetskrav-siden viser vi nå friteksten som sendes ut sammen med et forhåndsvarsel, men tanken er også at veileder skal kunne se hele brevet som ble sendt. Da må vi sende med DocumentComponent, og vise denne frem. Det blir litt lignende logikk som i dialogmeldinger 👍🏼