### PR TITLE
IS-1749: Add create new aktivitetskrav endpoint

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -78,7 +78,7 @@ fun main() {
     )
 
     val aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(
-        kafkaProducerAktivitetskravVurdering = KafkaProducer(
+        producer = KafkaProducer(
             aktivitetskravVurderingProducerConfig(kafkaEnvironment = environment.kafka)
         )
     )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -31,9 +31,9 @@ class AktivitetskravService(
         )
     }
 
-    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskrav: UUID?): PAktivitetskrav {
+    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID?): PAktivitetskrav {
         val newAktivitetskrav = Aktivitetskrav.create(personIdent)
-        return aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskrav)
+        return aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskravUuid)
     }
 
     internal fun updateAktivitetskravStoppunkt(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -34,11 +34,12 @@ class AktivitetskravService(
     fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID? = null): Aktivitetskrav {
         val aktivitetskrav = Aktivitetskrav.create(personIdent)
         val createdAktivitetskrav =
-            aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid).toAktivitetskrav()
+            aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid)
         aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
-            aktivitetskrav = createdAktivitetskrav,
+            aktivitetskrav = createdAktivitetskrav.toAktivitetskrav(),
+            previousAktivitetskravUuid = createdAktivitetskrav.previousAktivitetskravUuid,
         )
-        return createdAktivitetskrav
+        return createdAktivitetskrav.toAktivitetskrav()
     }
 
     internal fun updateAktivitetskravStoppunkt(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -31,9 +31,14 @@ class AktivitetskravService(
         )
     }
 
-    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID? = null): PAktivitetskrav {
+    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID? = null): Aktivitetskrav {
         val aktivitetskrav = Aktivitetskrav.create(personIdent)
-        return aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid)
+        val createdAktivitetskrav =
+            aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid).toAktivitetskrav()
+        aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
+            aktivitetskrav = createdAktivitetskrav,
+        )
+        return createdAktivitetskrav
     }
 
     internal fun updateAktivitetskravStoppunkt(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -31,6 +31,11 @@ class AktivitetskravService(
         )
     }
 
+    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskrav: UUID?): PAktivitetskrav {
+        val newAktivitetskrav = Aktivitetskrav.newManuallyCreated(personIdent)
+        return aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskrav)
+    }
+
     internal fun updateAktivitetskravStoppunkt(
         connection: Connection,
         aktivitetskrav: Aktivitetskrav,
@@ -61,6 +66,8 @@ class AktivitetskravService(
             aktivitetskrav = updatedAktivitetskrav
         )
     }
+
+    // Add function for making a new vurdering `NY_VURDERING` or create new aktivitetskrav
 
     internal fun oppfyllAutomatisk(connection: Connection, aktivitetskrav: Aktivitetskrav) {
         val updatedAktivitetskrav = aktivitetskrav.oppfyllAutomatisk()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -32,8 +32,8 @@ class AktivitetskravService(
     }
 
     fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID? = null): PAktivitetskrav {
-        val newAktivitetskrav = Aktivitetskrav.create(personIdent)
-        return aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskravUuid)
+        val aktivitetskrav = Aktivitetskrav.create(personIdent)
+        return aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid)
     }
 
     internal fun updateAktivitetskravStoppunkt(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -34,12 +34,12 @@ class AktivitetskravService(
     fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID? = null): Aktivitetskrav {
         val aktivitetskrav = Aktivitetskrav.create(personIdent)
         val createdAktivitetskrav =
-            aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid)
+            aktivitetskravRepository.createAktivitetskrav(aktivitetskrav, previousAktivitetskravUuid).toAktivitetskrav()
         aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
-            aktivitetskrav = createdAktivitetskrav.toAktivitetskrav(),
-            previousAktivitetskravUuid = createdAktivitetskrav.previousAktivitetskravUuid,
+            aktivitetskrav = createdAktivitetskrav,
+            previousAktivitetskravUuid = previousAktivitetskravUuid,
         )
-        return createdAktivitetskrav.toAktivitetskrav()
+        return createdAktivitetskrav
     }
 
     internal fun updateAktivitetskravStoppunkt(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -31,7 +31,7 @@ class AktivitetskravService(
         )
     }
 
-    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID?): PAktivitetskrav {
+    fun createAktivitetskrav(personIdent: PersonIdent, previousAktivitetskravUuid: UUID? = null): PAktivitetskrav {
         val newAktivitetskrav = Aktivitetskrav.create(personIdent)
         return aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskravUuid)
     }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -54,10 +54,10 @@ fun Route.registerAktivitetskravApi(
         }
         post {
             val personIdent = call.personIdent()
-            val requestDTO = call.receiveNullable<NewAktivitetskravDTO>()
+            val requestDTO: NewAktivitetskravDTO? = call.receiveNullable<NewAktivitetskravDTO>()
 
             val createdAktivitetskrav =
-                aktivitetskravService.createAktivitetskrav(personIdent, requestDTO?.previousAktivitetskrav)
+                aktivitetskravService.createAktivitetskrav(personIdent, requestDTO?.previousAktivitetskravUuid)
 
             call.respond(HttpStatusCode.Created, createdAktivitetskrav)
         }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -111,6 +111,7 @@ fun Route.registerAktivitetskravApi(
 
             if (
                 aktivitetskrav.status != AktivitetskravStatus.NY &&
+                aktivitetskrav.status != AktivitetskravStatus.NY_VURDERING &&
                 aktivitetskrav.status != AktivitetskravStatus.AVVENT
             ) {
                 throw IllegalArgumentException("Failed to create forhandsvarsel: aktivitetskrav is not in a valid state")

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -54,10 +54,10 @@ fun Route.registerAktivitetskravApi(
         }
         post {
             val personIdent = call.personIdent()
-            // val requestDTO: NewAktivitetskravDTO? = call.receiveNullable<NewAktivitetskravDTO>()
-
+            val requestDTO: NewAktivitetskravDTO? =
+                runCatching { call.receiveNullable<NewAktivitetskravDTO>() }.getOrNull()
             val createdAktivitetskrav =
-                aktivitetskravService.createAktivitetskrav(personIdent, null)
+                aktivitetskravService.createAktivitetskrav(personIdent, requestDTO?.previousAktivitetskravUuid)
 
             call.respond(HttpStatusCode.Created, createdAktivitetskrav)
         }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -54,10 +54,10 @@ fun Route.registerAktivitetskravApi(
         }
         post {
             val personIdent = call.personIdent()
-            val requestDTO: NewAktivitetskravDTO? = call.receiveNullable<NewAktivitetskravDTO>()
+            // val requestDTO: NewAktivitetskravDTO? = call.receiveNullable<NewAktivitetskravDTO>()
 
             val createdAktivitetskrav =
-                aktivitetskravService.createAktivitetskrav(personIdent, requestDTO?.previousAktivitetskravUuid)
+                aktivitetskravService.createAktivitetskrav(personIdent, null)
 
             call.respond(HttpStatusCode.Created, createdAktivitetskrav)
         }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -52,6 +52,16 @@ fun Route.registerAktivitetskravApi(
 
             call.respond(responseDTOList)
         }
+        // Needs to support when there is an original aktivitetskrav, and when it is manually created first time
+        post {
+            val personIdent = call.personIdent()
+            val requestDTO = call.receiveNullable<NewAktivitetskravDTO>()
+
+            val createdAktivitetskrav =
+                aktivitetskravService.createAktivitetskrav(personIdent, requestDTO?.previousAktivitetskrav)
+
+            call.respond(HttpStatusCode.Created, createdAktivitetskrav)
+        }
         post("/{$aktivitetskravParam}$vurderAktivitetskravPath") {
             val personIdent = call.personIdent()
             val aktivitetskravUUID = UUID.fromString(call.parameters[aktivitetskravParam])

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/NewAktivitetskravDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/NewAktivitetskravDTO.kt
@@ -3,5 +3,5 @@ package no.nav.syfo.aktivitetskrav.api
 import java.util.*
 
 data class NewAktivitetskravDTO(
-    val previousAktivitetskrav: UUID
+    val previousAktivitetskravUuid: UUID
 )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/NewAktivitetskravDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/NewAktivitetskravDTO.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.aktivitetskrav.api
+
+import java.util.*
+
+data class NewAktivitetskravDTO(
+    val previousAktivitetskrav: UUID
+)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
@@ -42,7 +42,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
         previousAktivitetskravUuid: UUID?,
     ): PAktivitetskrav {
         val createdRecord = database.connection.use { connection ->
-            connection.prepareStatement(CREATE_AKTIVITETSKRAV_NY_VURDERING).use {
+            connection.prepareStatement(CREATE_AKTIVITETSKRAV).use {
                 it.setString(1, newAktivitetskrav.uuid.toString())
                 it.setObject(2, newAktivitetskrav.createdAt)
                 it.setObject(3, newAktivitetskrav.createdAt)
@@ -50,7 +50,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
                 it.setString(5, newAktivitetskrav.status.name)
                 it.setDate(6, Date.valueOf(newAktivitetskrav.stoppunktAt))
                 it.setString(7, null)
-                it.setString(8, previousAktivitetskravUuid.toString())
+                it.setObject(8, previousAktivitetskravUuid)
                 it.executeQuery().toList { toPAktivitetskrav() }
             }
         }
@@ -85,7 +85,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
             ORDER BY created_at DESC
             """
 
-        private const val CREATE_AKTIVITETSKRAV_NY_VURDERING =
+        private const val CREATE_AKTIVITETSKRAV =
             """
             INSERT INTO AKTIVITETSKRAV (
                 id,
@@ -96,7 +96,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
                 status,
                 stoppunkt_at,
                 referanse_tilfelle_bit_uuid,
-                previous_aktivitetskrav_uuid,
+                previous_aktivitetskrav_uuid
             ) values (DEFAULT, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING *
             """

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
@@ -39,7 +39,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
 
     fun createAktivitetskrav(
         newAktivitetskrav: Aktivitetskrav,
-        previousAktivitetskrav: UUID?,
+        previousAktivitetskravUuid: UUID?,
     ): PAktivitetskrav {
         val createdRecord = database.connection.use { connection ->
             connection.prepareStatement(CREATE_AKTIVITETSKRAV_NY_VURDERING).use {
@@ -50,7 +50,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
                 it.setString(5, newAktivitetskrav.status.name)
                 it.setDate(6, Date.valueOf(newAktivitetskrav.stoppunktAt))
                 it.setString(7, null)
-                it.setString(8, previousAktivitetskrav.toString())
+                it.setString(8, previousAktivitetskravUuid.toString())
                 it.executeQuery().toList { toPAktivitetskrav() }
             }
         }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
@@ -41,8 +41,8 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
         aktivitetskrav: Aktivitetskrav,
         previousAktivitetskravUuid: UUID?,
     ): PAktivitetskrav {
-        val createdRecord = database.connection.use { connection ->
-            val newRecord = connection.prepareStatement(CREATE_AKTIVITETSKRAV).use {
+        val createdRecords = database.connection.use { connection ->
+            val newRecords = connection.prepareStatement(CREATE_AKTIVITETSKRAV).use {
                 it.setString(1, aktivitetskrav.uuid.toString())
                 it.setObject(2, aktivitetskrav.createdAt)
                 it.setObject(3, aktivitetskrav.createdAt)
@@ -54,12 +54,12 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
                 it.executeQuery().toList { toPAktivitetskrav() }
             }
             connection.commit()
-            newRecord
+            newRecords
         }
-        if (createdRecord.size != 1) {
+        if (createdRecords.size != 1) {
             throw NoElementInsertedException("Creating AKTIVITETSKRAV failed, no rows affected.")
         }
-        return createdRecord.first()
+        return createdRecords.first()
     }
 
     private fun Connection.getAktivitetskravVurderinger(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
@@ -42,7 +42,7 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
         previousAktivitetskravUuid: UUID?,
     ): PAktivitetskrav {
         val createdRecord = database.connection.use { connection ->
-            connection.prepareStatement(CREATE_AKTIVITETSKRAV).use {
+            val newRecord = connection.prepareStatement(CREATE_AKTIVITETSKRAV).use {
                 it.setString(1, aktivitetskrav.uuid.toString())
                 it.setObject(2, aktivitetskrav.createdAt)
                 it.setObject(3, aktivitetskrav.createdAt)
@@ -53,6 +53,8 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
                 it.setObject(8, previousAktivitetskravUuid)
                 it.executeQuery().toList { toPAktivitetskrav() }
             }
+            connection.commit()
+            newRecord
         }
         if (createdRecord.size != 1) {
             throw NoElementInsertedException("Creating AKTIVITETSKRAV failed, no rows affected.")

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
@@ -120,6 +120,7 @@ private fun ResultSet.toPAktivitetskrav(): PAktivitetskrav = PAktivitetskrav(
     status = getString("status"),
     stoppunktAt = getDate("stoppunkt_at").toLocalDate(),
     referanseTilfelleBitUuid = getString("referanse_tilfelle_bit_uuid")?.let { UUID.fromString(it) },
+    previousAktivitetskravUuid = getObject("previous_aktivitetskrav_uuid", UUID::class.java),
 )
 
 private fun ResultSet.toPAktivitetskravVurdering(): PAktivitetskravVurdering = PAktivitetskravVurdering(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepository.kt
@@ -38,17 +38,17 @@ class AktivitetskravRepository(private val database: DatabaseInterface) {
         }
 
     fun createAktivitetskrav(
-        newAktivitetskrav: Aktivitetskrav,
+        aktivitetskrav: Aktivitetskrav,
         previousAktivitetskravUuid: UUID?,
     ): PAktivitetskrav {
         val createdRecord = database.connection.use { connection ->
             connection.prepareStatement(CREATE_AKTIVITETSKRAV).use {
-                it.setString(1, newAktivitetskrav.uuid.toString())
-                it.setObject(2, newAktivitetskrav.createdAt)
-                it.setObject(3, newAktivitetskrav.createdAt)
-                it.setString(4, newAktivitetskrav.personIdent.value)
-                it.setString(5, newAktivitetskrav.status.name)
-                it.setDate(6, Date.valueOf(newAktivitetskrav.stoppunktAt))
+                it.setString(1, aktivitetskrav.uuid.toString())
+                it.setObject(2, aktivitetskrav.createdAt)
+                it.setObject(3, aktivitetskrav.createdAt)
+                it.setString(4, aktivitetskrav.personIdent.value)
+                it.setString(5, aktivitetskrav.status.name)
+                it.setDate(6, Date.valueOf(aktivitetskrav.stoppunktAt))
                 it.setString(7, null)
                 it.setObject(8, previousAktivitetskravUuid)
                 it.executeQuery().toList { toPAktivitetskrav() }

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVurderingQueries.kt
@@ -216,6 +216,7 @@ private fun ResultSet.toPAktivitetskrav(): PAktivitetskrav = PAktivitetskrav(
     status = getString("status"),
     stoppunktAt = getDate("stoppunkt_at").toLocalDate(),
     referanseTilfelleBitUuid = getString("referanse_tilfelle_bit_uuid")?.let { UUID.fromString(it) },
+    previousAktivitetskravUuid = getObject("previous_aktivitetskrav_uuid", UUID::class.java),
 )
 
 private fun ResultSet.toPAktivitetskravVurdering(): PAktivitetskravVurdering = PAktivitetskravVurdering(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/PAktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/PAktivitetskrav.kt
@@ -17,6 +17,7 @@ data class PAktivitetskrav(
     val status: String,
     val stoppunktAt: LocalDate,
     val referanseTilfelleBitUuid: UUID?,
+    val previousAktivitetskravUuid: UUID?,
     val vurderinger: List<PAktivitetskravVurdering> = emptyList(),
 ) {
 

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -75,7 +75,7 @@ data class Aktivitetskrav(
     }
 }
 
-fun Aktivitetskrav.toKafkaAktivitetskravVurdering(): KafkaAktivitetskravVurdering {
+fun Aktivitetskrav.toKafkaAktivitetskravVurdering(previousAktivitetskravUuid: UUID? = null): KafkaAktivitetskravVurdering {
     val latestVurdering = this.vurderinger.firstOrNull()
     return KafkaAktivitetskravVurdering(
         uuid = this.uuid.toString(),
@@ -89,6 +89,7 @@ fun Aktivitetskrav.toKafkaAktivitetskravVurdering(): KafkaAktivitetskravVurderin
         sisteVurderingUuid = latestVurdering?.uuid?.toString(),
         sistVurdert = latestVurdering?.createdAt,
         frist = latestVurdering?.frist,
+        previousAktivitetskravUuid = previousAktivitetskravUuid,
     )
 }
 

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -78,7 +78,7 @@ data class Aktivitetskrav(
 fun Aktivitetskrav.toKafkaAktivitetskravVurdering(previousAktivitetskravUuid: UUID? = null): KafkaAktivitetskravVurdering {
     val latestVurdering = this.vurderinger.firstOrNull()
     return KafkaAktivitetskravVurdering(
-        uuid = this.uuid.toString(),
+        uuid = this.uuid,
         personIdent = this.personIdent.value,
         createdAt = this.createdAt,
         status = this.status.name,
@@ -86,7 +86,7 @@ fun Aktivitetskrav.toKafkaAktivitetskravVurdering(previousAktivitetskravUuid: UU
         stoppunktAt = this.stoppunktAt,
         updatedBy = latestVurdering?.createdBy,
         arsaker = latestVurdering?.arsaker?.map { it.name } ?: emptyList(),
-        sisteVurderingUuid = latestVurdering?.uuid?.toString(),
+        sisteVurderingUuid = latestVurdering?.uuid,
         sistVurdert = latestVurdering?.createdAt,
         frist = latestVurdering?.frist,
         previousAktivitetskravUuid = previousAktivitetskravUuid,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -39,14 +39,14 @@ data class Aktivitetskrav(
 
         fun create(
             personIdent: PersonIdent,
-            oppfolgningstilfelleStart: LocalDate? = null,
+            oppfolgingstilfelleStart: LocalDate? = null,
             isAutomatiskOppfylt: Boolean = false,
         ): Aktivitetskrav {
-            val isGeneratedAsOppfolgningstilfelle = oppfolgningstilfelleStart != null
+            val isGeneratedFromOppfolgingstilfelle = oppfolgingstilfelleStart != null
             val status =
                 if (isAutomatiskOppfylt) {
                     AktivitetskravStatus.AUTOMATISK_OPPFYLT
-                } else if (isGeneratedAsOppfolgningstilfelle) {
+                } else if (isGeneratedFromOppfolgingstilfelle) {
                     AktivitetskravStatus.NY
                 } else {
                     AktivitetskravStatus.NY_VURDERING
@@ -54,7 +54,7 @@ data class Aktivitetskrav(
             return create(
                 personIdent = personIdent,
                 status = status,
-                stoppunktAt = oppfolgningstilfelleStart?.let { stoppunktDato(it) } ?: run { LocalDate.now() },
+                stoppunktAt = oppfolgingstilfelleStart?.let { stoppunktDato(it) } ?: LocalDate.now(),
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -15,6 +15,7 @@ const val AKTIVITETSKRAV_STOPPUNKT_WEEKS = 8L
 
 enum class AktivitetskravStatus {
     NY,
+    NY_VURDERING,
     AVVENT,
     UNNTAK,
     OPPFYLT,
@@ -40,6 +41,13 @@ data class Aktivitetskrav(
                 personIdent = personIdent,
                 status = AktivitetskravStatus.NY,
                 stoppunktAt = stoppunktDato(tilfelleStart),
+            )
+
+        fun newManuallyCreated(personIdent: PersonIdent): Aktivitetskrav =
+            create(
+                personIdent = personIdent,
+                status = AktivitetskravStatus.NY_VURDERING,
+                stoppunktAt = LocalDate.now(),
             )
 
         fun automatiskOppfylt(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravMetrics.kt
@@ -27,7 +27,7 @@ val COUNT_UNNTAK: Counter =
 
 val COUNT_NY_VURDERING: Counter =
     Counter.builder(NY_VURDERING)
-        .description("Counts the number vurderinger with status AVVENT created")
+        .description("Counts the number vurderinger with status NY_VURDERING created")
         .register(METRICS_REGISTRY)
 
 val COUNT_AVVENT: Counter =

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravMetrics.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravMetrics.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.application.metric.METRICS_REGISTRY
 const val AKTIVITETSKRAV_KAFKA_METRIC_BASE = "${METRICS_NS}_kafka_producer"
 const val AKTIVITETSKRAV_VURDERING_KAFKA = "${AKTIVITETSKRAV_KAFKA_METRIC_BASE}_vurdering"
 const val UNNTAK = "${AKTIVITETSKRAV_VURDERING_KAFKA}_unntak"
+const val NY_VURDERING = "${AKTIVITETSKRAV_VURDERING_KAFKA}_ny_vurdering"
 const val AVVENT = "${AKTIVITETSKRAV_VURDERING_KAFKA}_avvent"
 const val OPPFYLT = "${AKTIVITETSKRAV_VURDERING_KAFKA}_oppfylt"
 const val STANS = "${AKTIVITETSKRAV_VURDERING_KAFKA}_stans"
@@ -22,6 +23,11 @@ val COUNT_FORHANDSVARSEL: Counter =
 val COUNT_UNNTAK: Counter =
     Counter.builder(UNNTAK)
         .description("Counts the number vurderinger with status UNNTAK created")
+        .register(METRICS_REGISTRY)
+
+val COUNT_NY_VURDERING: Counter =
+    Counter.builder(NY_VURDERING)
+        .description("Counts the number vurderinger with status AVVENT created")
         .register(METRICS_REGISTRY)
 
 val COUNT_AVVENT: Counter =

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
@@ -17,8 +17,10 @@ class AktivitetskravVurderingProducer(
 ) {
     fun sendAktivitetskravVurdering(
         aktivitetskrav: Aktivitetskrav,
+        previousAktivitetskravUuid: UUID? = null,
     ) {
-        val kafkaAktivitetskravVurdering = aktivitetskrav.toKafkaAktivitetskravVurdering()
+        val kafkaAktivitetskravVurdering =
+            aktivitetskrav.toKafkaAktivitetskravVurdering(previousAktivitetskravUuid = previousAktivitetskravUuid)
         val key = UUID.nameUUIDFromBytes(kafkaAktivitetskravVurdering.personIdent.toByteArray()).toString()
         try {
             producer.send(

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import java.util.*
 
 class AktivitetskravVurderingProducer(
-    private val kafkaProducerAktivitetskravVurdering: KafkaProducer<String, KafkaAktivitetskravVurdering>,
+    private val producer: KafkaProducer<String, KafkaAktivitetskravVurdering>,
 ) {
     fun sendAktivitetskravVurdering(
         aktivitetskrav: Aktivitetskrav,
@@ -21,7 +21,7 @@ class AktivitetskravVurderingProducer(
         val kafkaAktivitetskravVurdering = aktivitetskrav.toKafkaAktivitetskravVurdering()
         val key = UUID.nameUUIDFromBytes(kafkaAktivitetskravVurdering.personIdent.toByteArray()).toString()
         try {
-            kafkaProducerAktivitetskravVurdering.send(
+            producer.send(
                 ProducerRecord(
                     AKTIVITETSKRAV_VURDERING_TOPIC,
                     key,
@@ -34,6 +34,7 @@ class AktivitetskravVurderingProducer(
                 kafkaAktivitetskravVurdering.uuid
             )
             when (kafkaAktivitetskravVurdering.status) {
+                AktivitetskravStatus.NY_VURDERING.name -> COUNT_NY_VURDERING.increment()
                 AktivitetskravStatus.AVVENT.name -> COUNT_AVVENT.increment()
                 AktivitetskravStatus.UNNTAK.name -> COUNT_UNNTAK.increment()
                 AktivitetskravStatus.OPPFYLT.name -> COUNT_OPPFYLT.increment()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurdering.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.aktivitetskrav.kafka.domain
 
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.util.*
 
 data class KafkaAktivitetskravVurdering(
     val uuid: String,
@@ -15,4 +16,5 @@ data class KafkaAktivitetskravVurdering(
     val sisteVurderingUuid: String?,
     val sistVurdert: OffsetDateTime?,
     val frist: LocalDate?,
+    val previousAktivitetskravUuid: UUID?,
 )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/domain/KafkaAktivitetskravVurdering.kt
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime
 import java.util.*
 
 data class KafkaAktivitetskravVurdering(
-    val uuid: String,
+    val uuid: UUID,
     val personIdent: String,
     val createdAt: OffsetDateTime,
     val status: String,
@@ -13,7 +13,7 @@ data class KafkaAktivitetskravVurdering(
     val arsaker: List<String>,
     val stoppunktAt: LocalDate,
     val updatedBy: String?,
-    val sisteVurderingUuid: String?,
+    val sisteVurderingUuid: UUID?,
     val sistVurdert: OffsetDateTime?,
     val frist: LocalDate?,
     val previousAktivitetskravUuid: UUID?,

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -117,7 +117,7 @@ class KafkaOppfolgingstilfellePersonService(
     ) {
         val aktivitetskrav = Aktivitetskrav.create(
             personIdent = oppfolgingstilfelle.personIdent,
-            oppfolgningstilfelleStart = oppfolgingstilfelle.tilfelleStart,
+            oppfolgingstilfelleStart = oppfolgingstilfelle.tilfelleStart,
             isAutomatiskOppfylt = oppfolgingstilfelle.isGradertAtTilfelleEnd(),
         )
         aktivitetskravService.createAktivitetskrav(

--- a/src/main/resources/db/migration/V3_5__add_original_aktivitetskrav_uuid.sql
+++ b/src/main/resources/db/migration/V3_5__add_original_aktivitetskrav_uuid.sql
@@ -1,0 +1,2 @@
+ALTER TABLE AKTIVITETSKRAV
+ADD COLUMN original_aktivitetskrav_uuid UUID;

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravServiceSpek.kt
@@ -1,0 +1,87 @@
+package no.nav.syfo.aktivitetskrav
+
+import io.ktor.server.testing.*
+import io.mockk.*
+import no.nav.syfo.aktivitetskrav.database.AktivitetskravRepository
+import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
+import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.dropData
+import org.amshove.kluent.shouldBeEqualTo
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+import java.util.concurrent.Future
+
+class AktivitetskravServiceSpek : Spek({
+
+    describe(AktivitetskravService::class.java.simpleName) {
+        with(TestApplicationEngine()) {
+            start()
+            val externalMockEnvironment = ExternalMockEnvironment.instance
+            val database = externalMockEnvironment.database
+            val vurderingProducerMock = mockk<KafkaProducer<String, KafkaAktivitetskravVurdering>>()
+            val aktivitetskravRepository = AktivitetskravRepository(database = database)
+            val aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(vurderingProducerMock)
+            val aktivitetskravService = AktivitetskravService(
+                aktivitetskravRepository = aktivitetskravRepository,
+                aktivitetskravVurderingProducer = aktivitetskravVurderingProducer,
+                database = database,
+                arenaCutoff = externalMockEnvironment.environment.arenaCutoff,
+            )
+
+            beforeEachTest {
+                clearMocks(vurderingProducerMock)
+                coEvery {
+                    vurderingProducerMock.send(any())
+                } returns mockk<Future<RecordMetadata>>(relaxed = true)
+            }
+            afterEachTest {
+                database.dropData()
+            }
+
+            describe("create aktivitetskrav") {
+                it("creates aktivitetskrav with previous aktivitetskrav from service") {
+                    val previousAktivitetskravUuid = UUID.randomUUID()
+                    val createdAktivitetskrav =
+                        aktivitetskravService.createAktivitetskrav(
+                            UserConstants.ARBEIDSTAKER_PERSONIDENT,
+                            previousAktivitetskravUuid = previousAktivitetskravUuid
+                        )
+                    val savedAktivitetskrav = aktivitetskravRepository.getAktivitetskrav(createdAktivitetskrav.uuid)
+                    val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
+
+                    verify(exactly = 1) {
+                        vurderingProducerMock.send(capture(producerRecordSlot))
+                    }
+
+                    val aktivitetskravVurderingRecord = producerRecordSlot.captured.value()
+                    createdAktivitetskrav.personIdent.value shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
+                    savedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskravUuid
+                    aktivitetskravVurderingRecord.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskravUuid
+                    aktivitetskravVurderingRecord.uuid shouldBeEqualTo createdAktivitetskrav.uuid
+                }
+                it("creates aktivitetskrav without previous aktivitetskrav from service") {
+                    val createdAktivitetskrav =
+                        aktivitetskravService.createAktivitetskrav(UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                    val savedAktivitetskrav = aktivitetskravRepository.getAktivitetskrav(createdAktivitetskrav.uuid)
+                    val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
+
+                    verify(exactly = 1) {
+                        vurderingProducerMock.send(capture(producerRecordSlot))
+                    }
+
+                    val aktivitetskravVurderingRecord = producerRecordSlot.captured.value()
+                    createdAktivitetskrav.personIdent.value shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
+                    savedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo null
+                    aktivitetskravVurderingRecord.previousAktivitetskravUuid shouldBeEqualTo null
+                    aktivitetskravVurderingRecord.uuid shouldBeEqualTo createdAktivitetskrav.uuid
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -168,7 +168,7 @@ class AktivitetskravSpek : Spek({
             kafkaAktivitetskravVurdering.beskrivelse shouldBeEqualTo "Oppfylt"
             kafkaAktivitetskravVurdering.arsaker shouldBeEqualTo listOf(VurderingArsak.FRISKMELDT.name)
             kafkaAktivitetskravVurdering.sistVurdert shouldBeEqualTo oppfyltVurdering.createdAt
-            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo oppfyltVurdering.uuid.toString()
+            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo oppfyltVurdering.uuid
             kafkaAktivitetskravVurdering.frist shouldBeEqualTo null
         }
         it("updatedBy, sisteVurderingUuid, sistVurdert, frist and beskrivelse is null when not vurdert") {

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -308,7 +308,7 @@ class AktivitetskravApiSpek : Spek({
                             kafkaAktivitetskravVurdering.arsaker shouldBeEqualTo listOf(VurderingArsak.FRISKMELDT.name)
                             kafkaAktivitetskravVurdering.updatedBy shouldBeEqualTo UserConstants.VEILEDER_IDENT
                             kafkaAktivitetskravVurdering.sistVurdert?.millisekundOpplosning() shouldBeEqualTo aktivitetskravVurdering.createdAt.millisekundOpplosning()
-                            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo aktivitetskravVurdering.uuid.toString()
+                            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo aktivitetskravVurdering.uuid
                             kafkaAktivitetskravVurdering.stoppunktAt shouldBeEqualTo aktivitetskrav.stoppunktAt
                         }
                     }
@@ -354,26 +354,6 @@ class AktivitetskravApiSpek : Spek({
                             responseDTO.personIdent.value shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
                             kafkaAktivitetskravVurdering.previousAktivitetskravUuid shouldBeEqualTo null
                         }
-                    }
-                    it("creates aktivitetskrav with previous aktivitetskrav from service") {
-                        val previousAktivitetskravUuid = UUID.randomUUID()
-                        val aktivitetskrav =
-                            aktivitetskravService.createAktivitetskrav(
-                                UserConstants.ARBEIDSTAKER_PERSONIDENT,
-                                previousAktivitetskravUuid = previousAktivitetskravUuid
-                            )
-                        val savedAktivitetskrav = aktivitetskravRepository.getAktivitetskrav(aktivitetskrav.uuid)
-
-                        aktivitetskrav.personIdent.value shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
-                        savedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskravUuid
-                    }
-                    it("creates aktivitetskrav without previous aktivitetskrav from service") {
-                        val aktivitetskrav =
-                            aktivitetskravService.createAktivitetskrav(UserConstants.ARBEIDSTAKER_PERSONIDENT)
-                        val savedAktivitetskrav = aktivitetskravRepository.getAktivitetskrav(aktivitetskrav.uuid)
-
-                        aktivitetskrav.personIdent.value shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
-                        savedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo null
                     }
                 }
 
@@ -551,7 +531,7 @@ class AktivitetskravApiSpek : Spek({
                             kafkaAktivitetskravVurdering.beskrivelse shouldBeEqualTo "Aktivitetskravet er oppfylt"
                             kafkaAktivitetskravVurdering.arsaker shouldBeEqualTo listOf(VurderingArsak.FRISKMELDT.name)
                             kafkaAktivitetskravVurdering.updatedBy shouldBeEqualTo UserConstants.VEILEDER_IDENT
-                            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo latestAktivitetskravVurdering.uuid.toString()
+                            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo latestAktivitetskravVurdering.uuid
                             kafkaAktivitetskravVurdering.sistVurdert?.millisekundOpplosning() shouldBeEqualTo latestAktivitetskravVurdering.createdAt.millisekundOpplosning()
                         }
                     }
@@ -600,7 +580,7 @@ class AktivitetskravApiSpek : Spek({
                             kafkaAktivitetskravVurdering.beskrivelse shouldBeEqualTo "Aktivitetskravet er oppfylt"
                             kafkaAktivitetskravVurdering.arsaker shouldBeEqualTo listOf(VurderingArsak.FRISKMELDT.name)
                             kafkaAktivitetskravVurdering.updatedBy shouldBeEqualTo UserConstants.VEILEDER_IDENT
-                            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo latestAktivitetskravVurdering.uuid.toString()
+                            kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo latestAktivitetskravVurdering.uuid
                             kafkaAktivitetskravVurdering.sistVurdert?.millisekundOpplosning() shouldBeEqualTo latestAktivitetskravVurdering.createdAt.millisekundOpplosning()
                         }
                     }

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -58,7 +58,7 @@ class AktivitetskravApiSpek : Spek({
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
                 aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(
-                    kafkaProducerAktivitetskravVurdering = kafkaProducer,
+                    producer = kafkaProducer,
                 ),
             )
             val aktivitetskravRepository = AktivitetskravRepository(database)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravAutomatiskOppfyltCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravAutomatiskOppfyltCronjobSpek.kt
@@ -32,7 +32,7 @@ class AktivitetskravAutomatiskOppfyltCronjobSpek : Spek({
 
         val kafkaProducer = mockk<KafkaProducer<String, KafkaAktivitetskravVurdering>>()
         val aktivitetskravVurderingProducer =
-            AktivitetskravVurderingProducer(kafkaProducerAktivitetskravVurdering = kafkaProducer)
+            AktivitetskravVurderingProducer(producer = kafkaProducer)
         val aktivitetskravRepository = AktivitetskravRepository(database)
         val aktivitetskravService = AktivitetskravService(
             aktivitetskravRepository = aktivitetskravRepository,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravNyCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/AktivitetskravNyCronjobSpek.kt
@@ -32,7 +32,7 @@ class AktivitetskravNyCronjobSpek : Spek({
 
         val kafkaProducer = mockk<KafkaProducer<String, KafkaAktivitetskravVurdering>>()
         val aktivitetskravVurderingProducer =
-            AktivitetskravVurderingProducer(kafkaProducerAktivitetskravVurdering = kafkaProducer)
+            AktivitetskravVurderingProducer(producer = kafkaProducer)
         val aktivitetskravRepository = AktivitetskravRepository(database)
         val aktivitetskravService = AktivitetskravService(
             aktivitetskravRepository = aktivitetskravRepository,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
@@ -37,12 +37,12 @@ val pdf = byteArrayOf(23)
 val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
 val aktivitetskrav = Aktivitetskrav.create(
     personIdent = personIdent,
-    oppfolgningstilfelleStart = LocalDate.now(),
+    oppfolgingstilfelleStart = LocalDate.now(),
 )
 val personIdentManglerNavn = UserConstants.ARBEIDSTAKER_PERSONIDENT_NO_NAME
 val aktivitetskravPersonManglerNavn = Aktivitetskrav.create(
     personIdent = personIdentManglerNavn,
-    oppfolgningstilfelleStart = LocalDate.now(),
+    oppfolgingstilfelleStart = LocalDate.now(),
 )
 
 val forhandsvarselDTO = generateForhandsvarsel("Et forhåndsvarsel")

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
@@ -31,7 +31,7 @@ class OutdatedAktivitetskravCronjobSpek : Spek({
     val aktivitetskravService = AktivitetskravService(
         aktivitetskravRepository = aktivitetskravRepository,
         database = database,
-        aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(kafkaProducerAktivitetskravVurdering = kafkaProducer),
+        aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(producer = kafkaProducer),
         arenaCutoff = arenaCutoff,
     )
     val outdatedAktivitetskravCronjob = OutdatedAktivitetskravCronjob(

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
@@ -50,7 +50,7 @@ class OutdatedAktivitetskravCronjobSpek : Spek({
 
     fun createNyttAktivitetskrav(stoppunktAt: LocalDate): Aktivitetskrav = Aktivitetskrav.create(
         personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
-        oppfolgningstilfelleStart = stoppunktAt.minusWeeks(8),
+        oppfolgingstilfelleStart = stoppunktAt.minusWeeks(8),
     )
 
     describe("${OutdatedAktivitetskravCronjob::class.java.simpleName}: run job") {

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/PubliserAktivitetskravVarselCronjobSpek.kt
@@ -29,7 +29,7 @@ class PubliserAktivitetskravVarselCronjobSpek : Spek({
     val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
     val aktivitetskrav = Aktivitetskrav.create(
         personIdent = personIdent,
-        oppfolgningstilfelleStart = LocalDate.now(),
+        oppfolgingstilfelleStart = LocalDate.now(),
     )
     val forhandsvarselDTO = generateForhandsvarsel("Et forhåndsvarsel")
     val pdf = byteArrayOf(23)

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
@@ -32,9 +32,11 @@ class AktivitetskravRepositorySpek : Spek({
             describe("Successfully creates an aktivitetskrav with previous aktivitetskrav") {
                 val newAktivitetskrav = Aktivitetskrav.create(UserConstants.ARBEIDSTAKER_PERSONIDENT)
                 val previousAktivitetskravUuid = UUID.randomUUID()
-                val createdAktivitetskrav =
-                    aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskravUuid)
-                createdAktivitetskrav.personIdent shouldBeEqualTo newAktivitetskrav.personIdent
+                aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskravUuid)
+                val storedAktivitetskrav = aktivitetskravRepository.getAktivitetskrav(newAktivitetskrav.uuid)
+
+                storedAktivitetskrav?.personIdent shouldBeEqualTo newAktivitetskrav.personIdent
+                storedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskravUuid
             }
 
             describe("Forhåndsvarsel") {

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravRepositorySpek.kt
@@ -13,6 +13,7 @@ import org.amshove.kluent.shouldBeGreaterThan
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 import java.time.LocalDate
+import java.util.UUID
 
 class AktivitetskravRepositorySpek : Spek({
 
@@ -26,6 +27,14 @@ class AktivitetskravRepositorySpek : Spek({
 
             afterEachTest {
                 database.dropData()
+            }
+
+            describe("Successfully creates an aktivitetskrav with previous aktivitetskrav") {
+                val newAktivitetskrav = Aktivitetskrav.create(UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                val previousAktivitetskravUuid = UUID.randomUUID()
+                val createdAktivitetskrav =
+                    aktivitetskravRepository.createAktivitetskrav(newAktivitetskrav, previousAktivitetskravUuid)
+                createdAktivitetskrav.personIdent shouldBeEqualTo newAktivitetskrav.personIdent
             }
 
             describe("Forhåndsvarsel") {

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -42,7 +42,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
         val arenaCutoff = externalMockEnvironment.environment.arenaCutoff
         val kafkaProducer = mockk<KafkaProducer<String, KafkaAktivitetskravVurdering>>()
         val aktivitetskravVurderingProducer = AktivitetskravVurderingProducer(
-            kafkaProducerAktivitetskravVurdering = kafkaProducer,
+            producer = kafkaProducer,
         )
         val aktivitetskravRepository = AktivitetskravRepository(database)
         val aktivitetskravService = AktivitetskravService(

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/AktivitetskravGenerator.kt
@@ -10,7 +10,7 @@ fun createAktivitetskravNy(
     personIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
 ): Aktivitetskrav = Aktivitetskrav.create(
     personIdent = personIdent,
-    oppfolgningstilfelleStart = tilfelleStart,
+    oppfolgingstilfelleStart = tilfelleStart,
 )
 
 fun createAktivitetskravAutomatiskOppfylt(
@@ -18,7 +18,7 @@ fun createAktivitetskravAutomatiskOppfylt(
     personIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
 ): Aktivitetskrav = Aktivitetskrav.create(
     personIdent = personIdent,
-    oppfolgningstilfelleStart = tilfelleStart,
+    oppfolgingstilfelleStart = tilfelleStart,
     isAutomatiskOppfylt = true,
 )
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til endepunkt for å lage en ny aktivitetskrav ressurs `POST /aktivitetskrav`. Har tenkt at dette skal gjelde både for når vi lager ny aktivitetskrav ressurs første gang (uten at det er generert et oppfølgningstilfelle, og når man som veileder går i gang med en ny runde med vurderinger. Det som skiller disse er om det sendes med en request body til endepunktet som inneholder det forrige aktivitetskravet's `UUID`
- Har også refaktorert litt i `Aktivitetskrav` ettersom jeg har blitt litt forvirret over hva `tilfelle` er og ikke skjønt at dette er et `oppfølgningstilfelle`. Tenker også at det er en fordel at vi har litt færre konstruktør metoder, og putter inn logikken for hvordan et `Aktivitetskrav` lages inn i konstruktørmetoden og at dette ikke lever utenfor 😊