### PR TITLE
IS-1778: Fjerner endepunkt for å opprette og vurdere aktivitetskrav

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -113,29 +113,6 @@ class AktivitetskravService(
         aktivitetskravVurderingProducer.sendAktivitetskravVurdering(aktivitetskrav = updatedAktivitetskrav)
     }
 
-    internal fun createAndVurderAktivitetskrav(
-        personIdent: PersonIdent,
-        aktivitetskravVurdering: AktivitetskravVurdering,
-    ) {
-        val aktivitetskrav =
-            Aktivitetskrav.fromVurdering(personIdent = personIdent, vurdering = aktivitetskravVurdering)
-
-        database.connection.use { connection ->
-            val pAktivitetskrav = connection.createAktivitetskrav(
-                aktivitetskrav = aktivitetskrav,
-                referanseTilfelleBitUUID = null
-            )
-            connection.createAktivitetskravVurdering(
-                aktivitetskravId = pAktivitetskrav.id,
-                aktivitetskravVurdering = aktivitetskravVurdering
-            )
-            connection.commit()
-        }
-        aktivitetskravVurderingProducer.sendAktivitetskravVurdering(
-            aktivitetskrav = aktivitetskrav,
-        )
-    }
-
     private fun withVurderinger(pAktivitetskrav: PAktivitetskrav): Aktivitetskrav {
         val aktivitetskravVurderinger =
             database.getAktivitetskravVurderinger(aktivitetskravId = pAktivitetskrav.id)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -84,20 +84,6 @@ fun Route.registerAktivitetskravApi(
 
             call.respond(HttpStatusCode.OK)
         }
-        post(vurderAktivitetskravPath) {
-            val personIdent = call.personIdent()
-            val requestDTO = call.receive<AktivitetskravVurderingRequestDTO>()
-
-            val aktivitetskravVurdering = requestDTO.toAktivitetskravVurdering(
-                createdByIdent = call.getNAVIdent(),
-            )
-            aktivitetskravService.createAndVurderAktivitetskrav(
-                personIdent = personIdent,
-                aktivitetskravVurdering = aktivitetskravVurdering
-            )
-
-            call.respond(HttpStatusCode.OK)
-        }
         post("/{$aktivitetskravParam}$forhandsvarselPath") {
             val aktivitetskravUUID = UUID.fromString(call.parameters[aktivitetskravParam])
             val requestDTO = call.receive<ForhandsvarselDTO>()

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -44,19 +44,6 @@ data class Aktivitetskrav(
             )
         }
 
-        fun fromVurdering(
-            personIdent: PersonIdent,
-            vurdering: AktivitetskravVurdering,
-        ): Aktivitetskrav {
-            val aktivitetskravNy = create(
-                personIdent = personIdent,
-                status = AktivitetskravStatus.NY,
-                stoppunktAt = LocalDate.now(),
-            )
-
-            return aktivitetskravNy.vurder(vurdering)
-        }
-
         private fun create(
             personIdent: PersonIdent,
             status: AktivitetskravStatus,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -183,24 +183,4 @@ class AktivitetskravSpek : Spek({
             kafkaAktivitetskravVurdering.sisteVurderingUuid shouldBeEqualTo null
         }
     }
-
-    describe("created from vurdering") {
-        it("has vurdering, status and stoppunkt today") {
-            val oppfyltVurdering = AktivitetskravVurdering.create(
-                status = AktivitetskravStatus.OPPFYLT,
-                createdBy = UserConstants.VEILEDER_IDENT,
-                beskrivelse = "Oppfylt",
-                arsaker = listOf(VurderingArsak.FRISKMELDT),
-            )
-
-            val aktivitetskrav = Aktivitetskrav.fromVurdering(
-                personIdent = ARBEIDSTAKER_PERSONIDENT,
-                vurdering = oppfyltVurdering,
-            )
-
-            aktivitetskrav.status shouldBeEqualTo AktivitetskravStatus.OPPFYLT
-            aktivitetskrav.vurderinger shouldBeEqualTo listOf(oppfyltVurdering)
-            aktivitetskrav.stoppunktAt shouldBeEqualTo LocalDate.now()
-        }
-    }
 })


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjerner endepunkt som ikke lenger er i bruk når https://github.com/navikt/syfomodiaperson/pull/1069 er merget. Erstattet av endepunkt for å opprette aktivitetskrav med status `NY_VURDERING`.