### PR TITLE
IS-1777: Validate previous aktivitetskrav exists and in final state

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravVarselService.kt
@@ -59,8 +59,8 @@ class AktivitetskravVarselService(
         if (aktivitetskrav.vurderinger.any { it.status == AktivitetskravStatus.FORHANDSVARSEL }) {
             throw ConflictException("Forhåndsvarsel allerede sendt")
         }
-        if (!aktivitetskrav.hasAllowedExistingStatusBeforeForhandsvarsel()) {
-            throw ConflictException("Kan bare sende forhåndsvarsel når status er NY, NY_VURDERING eller AVVENT, ikke ${aktivitetskrav.status}")
+        if (aktivitetskrav.isInFinalState()) {
+            throw ConflictException("Kan ikke sende forhåndsvarsel, aktivitetskravet har en avsluttende vurdering ${aktivitetskrav.status}")
         }
 
         val personNavn = pdlClient.navn(personIdent)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApi.kt
@@ -54,8 +54,11 @@ fun Route.registerAktivitetskravApi(
             val personIdent = call.personIdent()
             val requestDTO: NewAktivitetskravDTO? =
                 runCatching { call.receiveNullable<NewAktivitetskravDTO>() }.getOrNull()
+            val previousAktivitetskrav = requestDTO?.previousAktivitetskravUuid?.let {
+                aktivitetskravService.getAktivitetskrav(uuid = it) ?: throw IllegalArgumentException("Failed to create aktivitetskrav: previous aktivitetskrav not found")
+            }
             val createdAktivitetskrav =
-                aktivitetskravService.createAktivitetskrav(personIdent, requestDTO?.previousAktivitetskravUuid)
+                aktivitetskravService.createAktivitetskrav(personIdent, previousAktivitetskrav)
 
             call.respond(
                 HttpStatusCode.Created,

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravResponseDTO.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.aktivitetskrav.api
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravStatus
 import no.nav.syfo.aktivitetskrav.domain.VurderingArsak
+import no.nav.syfo.aktivitetskrav.domain.isInFinalState
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -21,7 +22,7 @@ data class AktivitetskravResponseDTO(
                 uuid = aktivitetskrav.uuid,
                 createdAt = aktivitetskrav.createdAt.toLocalDateTime(),
                 status = aktivitetskrav.status,
-                inFinalState = aktivitetskrav.status.isFinal,
+                inFinalState = aktivitetskrav.isInFinalState(),
                 stoppunktAt = aktivitetskrav.stoppunktAt,
                 vurderinger = vurderinger
             )

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -80,7 +80,7 @@ fun Aktivitetskrav.isAutomatiskOppfylt(): Boolean =
 
 fun Aktivitetskrav.isNy(): Boolean = this.status == AktivitetskravStatus.NY
 
-fun Aktivitetskrav.hasAllowedExistingStatusBeforeForhandsvarsel() = this.status.isAllowedStatusBeforeForhandsvarsel()
+fun Aktivitetskrav.isInFinalState() = this.status.isFinal
 
 internal fun Aktivitetskrav.shouldUpdateStoppunkt(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean {
     val updatedStoppunktDato = Aktivitetskrav.stoppunktDato(oppfolgingstilfelle.tilfelleStart)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravStatus.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/AktivitetskravStatus.kt
@@ -27,7 +27,5 @@ private val allowedChangedVurderingStatus = EnumSet.of(
     AktivitetskravStatus.FORHANDSVARSEL,
 )
 
-fun AktivitetskravStatus.isAllowedStatusBeforeForhandsvarsel() = !this.isFinal
-
 fun AktivitetskravStatus.requiresVurderingArsak(): Boolean =
     this == AktivitetskravStatus.AVVENT || this == AktivitetskravStatus.UNNTAK || this == AktivitetskravStatus.OPPFYLT

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravServiceSpek.kt
@@ -5,15 +5,20 @@ import io.mockk.*
 import no.nav.syfo.aktivitetskrav.database.AktivitetskravRepository
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
 import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
+import no.nav.syfo.application.exception.ConflictException
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.dropData
+import no.nav.syfo.testhelper.generator.createAktivitetskravNy
+import no.nav.syfo.testhelper.generator.createAktivitetskravOppfylt
+import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
 import java.util.*
 import java.util.concurrent.Future
 
@@ -46,11 +51,13 @@ class AktivitetskravServiceSpek : Spek({
 
             describe("create aktivitetskrav") {
                 it("creates aktivitetskrav with previous aktivitetskrav from service") {
-                    val previousAktivitetskravUuid = UUID.randomUUID()
+                    val previousAktivitetskrav = createAktivitetskravOppfylt(
+                        createAktivitetskravNy(tilfelleStart = LocalDate.now().minusWeeks(10))
+                    )
                     val createdAktivitetskrav =
                         aktivitetskravService.createAktivitetskrav(
                             UserConstants.ARBEIDSTAKER_PERSONIDENT,
-                            previousAktivitetskravUuid = previousAktivitetskravUuid
+                            previousAktivitetskrav = previousAktivitetskrav
                         )
                     val savedAktivitetskrav = aktivitetskravRepository.getAktivitetskrav(createdAktivitetskrav.uuid)
                     val producerRecordSlot = slot<ProducerRecord<String, KafkaAktivitetskravVurdering>>()
@@ -61,9 +68,18 @@ class AktivitetskravServiceSpek : Spek({
 
                     val aktivitetskravVurderingRecord = producerRecordSlot.captured.value()
                     createdAktivitetskrav.personIdent.value shouldBeEqualTo UserConstants.ARBEIDSTAKER_PERSONIDENT.value
-                    savedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskravUuid
-                    aktivitetskravVurderingRecord.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskravUuid
+                    savedAktivitetskrav?.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskrav.uuid
+                    aktivitetskravVurderingRecord.previousAktivitetskravUuid shouldBeEqualTo previousAktivitetskrav.uuid
                     aktivitetskravVurderingRecord.uuid shouldBeEqualTo createdAktivitetskrav.uuid
+                }
+                it("create aktivitetskrav with previous aktivitetskrav not final throws exception") {
+                    val previousAktivitetskrav = createAktivitetskravNy(tilfelleStart = LocalDate.now().minusWeeks(10))
+                    assertFailsWith(ConflictException::class) {
+                        aktivitetskravService.createAktivitetskrav(
+                            UserConstants.ARBEIDSTAKER_PERSONIDENT,
+                            previousAktivitetskrav = previousAktivitetskrav
+                        )
+                    }
                 }
                 it("creates aktivitetskrav without previous aktivitetskrav from service") {
                     val createdAktivitetskrav =


### PR DESCRIPTION
Når vi oppretter nytt aktivitetskrav og man har angitt `previousAktivitetskravUuid` bør vi validere at dette er et aktivitetskrav som eksisterer og at det er i sluttilstand.
La også til noen ekstra tester og litt forenkling av tilstandsjekken ifm forhåndsvarsel.