### PR TITLE
Delete vurdering with wrong begrunnelse

### DIFF
--- a/src/main/resources/db/migration/V3_6__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V3_6__delete_wrong_vurdering.sql
@@ -1,0 +1,12 @@
+DELETE
+FROM aktivitetskrav_vurdering
+WHERE uuid = 'd58cd2a2-18c1-404d-a55f-881fc7490ed1';
+
+UPDATE aktivitetskrav
+SET status = 'NY',
+    updated_at = now()
+WHERE uuid = 'd86af775-d05d-43b1-9497-11eb8a90b13c';
+
+DELETE
+FROM aktivitetskrav
+WHERE uuid = 'fd4c7555-3051-4006-9c06-cc85d28e3a42';


### PR DESCRIPTION
Also set status of aktivitetskrav to NY, delete ny_vurdering.
This will allow the veileder to make a new vurdering with correct input.
We assume the ny_vurdering is not needed and was only created because the veileder wanted to correct their mistake.