### PR TITLE
IS-1867: Add eksternReferanseId to journalpostRequest

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjob.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.client.dokarkiv.domain.*
 import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.domain.PersonIdent
 import org.slf4j.LoggerFactory
+import java.util.*
 
 class JournalforAktivitetskravVarselCronjob(
     private val aktivitetskravVarselService: AktivitetskravVarselService,
@@ -37,7 +38,8 @@ class JournalforAktivitetskravVarselCronjob(
                 val journalpostRequest = createJournalpostRequest(
                     personIdent = personIdent,
                     navn = navn,
-                    pdf = pdf
+                    pdf = pdf,
+                    varselUuid = varsel.uuid,
                 )
 
                 dokarkivClient.journalfor(
@@ -63,7 +65,7 @@ class JournalforAktivitetskravVarselCronjob(
     }
 }
 
-fun createJournalpostRequest(personIdent: PersonIdent, navn: String, pdf: ByteArray): JournalpostRequest {
+fun createJournalpostRequest(personIdent: PersonIdent, navn: String, pdf: ByteArray, varselUuid: UUID): JournalpostRequest {
     val avsenderMottaker = AvsenderMottaker.create(
         id = personIdent.value,
         idType = BrukerIdType.PERSON_IDENT,
@@ -101,6 +103,7 @@ fun createJournalpostRequest(personIdent: PersonIdent, navn: String, pdf: ByteAr
         tittel = dokumentTittel,
         bruker = bruker,
         dokumenter = dokumenter,
+        eksternReferanseId = varselUuid.toString(),
         kanal = kanal.value,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/domain/JournalpostRequest.kt
@@ -31,5 +31,6 @@ data class JournalpostRequest(
     val tema: String = JournalpostTema.OPPFOLGING.value,
     val kanal: String,
     val sak: Sak = Sak(),
+    val eksternReferanseId: String,
     val overstyrInnsynsregler: String? = null,
 )

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/JournalforAktivitetskravVarselCronjobSpek.kt
@@ -100,14 +100,15 @@ class JournalforAktivitetskravVarselCronjobSpek : Spek({
 
         describe("${JournalforAktivitetskravVarselCronjob::class.java.simpleName} runJob") {
             it("Journalfører og oppdaterer journalpostId for ikke-journalført forhandsvarsel") {
+                val varsel = createForhandsvarsel(aktivitetskrav = aktivitetskrav, pdf = pdf)
+
                 val expectedJournalpostRequestForhandsvarsel = generateJournalpostRequest(
                     tittel = "Forhåndsvarsel om stans av sykepenger",
                     brevkodeType = BrevkodeType.AKTIVITETSKRAV_FORHANDSVARSEL,
                     pdf = pdf,
                     kanal = JournalpostKanal.SENTRAL_UTSKRIFT.value,
+                    varselId = varsel.uuid,
                 )
-
-                val varsel = createForhandsvarsel(aktivitetskrav = aktivitetskrav, pdf = pdf)
 
                 coEvery { dokarkivClient.journalfor(any()) } returns anyJournalpostResponse
 
@@ -193,14 +194,15 @@ class JournalforAktivitetskravVarselCronjobSpek : Spek({
                 first.updatedAt.sekundOpplosning() shouldBeEqualTo first.createdAt.sekundOpplosning()
             }
             it("Oppdaterer ikke journalpostId når journalføring feiler") {
+                val varsel = createForhandsvarsel(aktivitetskrav = aktivitetskrav, pdf = pdf)
+
                 val expectedJournalpostRequestForhandsvarsel = generateJournalpostRequest(
                     tittel = "Forhåndsvarsel om stans av sykepenger",
                     brevkodeType = BrevkodeType.AKTIVITETSKRAV_FORHANDSVARSEL,
                     pdf = pdf,
                     kanal = JournalpostKanal.SENTRAL_UTSKRIFT.value,
+                    varselId = varsel.uuid,
                 )
-
-                val varsel = createForhandsvarsel(aktivitetskrav = aktivitetskrav, pdf = pdf)
 
                 coEvery { dokarkivClient.journalfor(any()) } throws RuntimeException("Journalføring feilet")
 

--- a/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
@@ -1,0 +1,59 @@
+package no.nav.syfo.client.dokarkiv
+
+import io.ktor.client.plugins.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.client.dokarkiv.domain.BrevkodeType
+import no.nav.syfo.client.dokarkiv.domain.JournalpostKanal
+import no.nav.syfo.testhelper.ExternalMockEnvironment
+import no.nav.syfo.testhelper.UserConstants
+import no.nav.syfo.testhelper.generator.generateJournalpostRequest
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.util.*
+
+class DokarkivClientSpek : Spek({
+    val externalMockEnvironment = ExternalMockEnvironment.instance
+    val dokarkivClient = DokarkivClient(
+        azureAdClient = externalMockEnvironment.azureAdClient,
+        dokarkivEnvironment = externalMockEnvironment.environment.clients.dokarkiv,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+
+    describe("${DokarkivClient::class.java.simpleName}: journalføring") {
+        val pdf = byteArrayOf(23)
+
+        it("journalfører aktivitetskrav") {
+            val journalpostRequestForhandsvarsel = generateJournalpostRequest(
+                tittel = "Forhåndsvarsel om stans av sykepenger",
+                brevkodeType = BrevkodeType.AKTIVITETSKRAV_FORHANDSVARSEL,
+                pdf = pdf,
+                kanal = JournalpostKanal.SENTRAL_UTSKRIFT.value,
+                varselId = UUID.randomUUID()
+            )
+
+            runBlocking {
+                val response = dokarkivClient.journalfor(journalpostRequest = journalpostRequestForhandsvarsel)
+
+                response.journalpostId shouldBeEqualTo 1
+            }
+        }
+
+        it("handles conflict from api when eksternRefeanseId exists") {
+            val journalpostRequestForhandsvarsel = generateJournalpostRequest(
+                tittel = "Forhåndsvarsel om stans av sykepenger",
+                brevkodeType = BrevkodeType.AKTIVITETSKRAV_FORHANDSVARSEL,
+                pdf = pdf,
+                kanal = JournalpostKanal.SENTRAL_UTSKRIFT.value,
+                varselId = UserConstants.EXISTING_EKSTERN_REFERANSE_UUID,
+            )
+
+            assertFailsWith<ClientRequestException> {
+                runBlocking {
+                    val response = dokarkivClient.journalfor(journalpostRequest = journalpostRequestForhandsvarsel)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.testhelper
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Virksomhetsnummer
+import java.util.UUID
 
 object UserConstants {
 
@@ -26,4 +27,6 @@ object UserConstants {
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer(VIRKSOMHETSNUMMER)
     const val VEILEDER_IDENT = "Z999999"
     const val OTHER_VEILEDER_IDENT = "Z999998"
+
+    val EXISTING_EKSTERN_REFERANSE_UUID: UUID = UUID.fromString("e7e8e9e0-e1e2-e3e4-e5e6-e7e8e9e0e1e2")
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
@@ -2,8 +2,9 @@ package no.nav.syfo.testhelper.generator
 
 import no.nav.syfo.client.dokarkiv.domain.*
 import no.nav.syfo.testhelper.UserConstants
+import java.util.UUID
 
-fun generateJournalpostRequest(tittel: String, brevkodeType: BrevkodeType, pdf: ByteArray, kanal: String) = JournalpostRequest(
+fun generateJournalpostRequest(tittel: String, brevkodeType: BrevkodeType, pdf: ByteArray, kanal: String, varselId: UUID) = JournalpostRequest(
     avsenderMottaker = AvsenderMottaker.create(
         id = UserConstants.ARBEIDSTAKER_PERSONIDENT.value,
         idType = BrukerIdType.PERSON_IDENT,
@@ -29,4 +30,5 @@ fun generateJournalpostRequest(tittel: String, brevkodeType: BrevkodeType, pdf: 
         )
     ),
     kanal = kanal,
+    eksternReferanseId = varselId.toString(),
 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
@@ -1,0 +1,24 @@
+package no.nav.syfo.testhelper.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.client.dokarkiv.domain.JournalpostRequest
+import no.nav.syfo.client.dokarkiv.domain.JournalpostResponse
+import no.nav.syfo.testhelper.UserConstants
+
+val response = JournalpostResponse(
+    journalpostId = 1,
+    journalpostferdigstilt = true,
+    journalstatus = "status",
+)
+
+suspend fun MockRequestHandleScope.dokarkivMockResponse(request: HttpRequestData): HttpResponseData {
+    val journalpostRequest = request.receiveBody<JournalpostRequest>()
+    val eksternReferanseId = journalpostRequest.eksternReferanseId
+
+    return when (eksternReferanseId) {
+        UserConstants.EXISTING_EKSTERN_REFERANSE_UUID.toString() -> respondError(HttpStatusCode.Conflict)
+        else -> respond(response)
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
@@ -19,6 +19,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
                     request
                 )
                 requestUrl.startsWith("/${environment.clients.pdl.baseUrl}") -> pdlMockResponse(request)
+                requestUrl.startsWith("/${environment.clients.dokarkiv.baseUrl}") -> dokarkivMockResponse(request)
                 else -> error("Unhandled ${request.url.encodedPath}")
             }
         }


### PR DESCRIPTION
If api receives an kesternReferanseId that is already stored, it will return 409 Conflict with the existing JournalPost as body.
We want to fail when we get 409 becuase we don't want to journalføre the same varsel more than once.