### PR TITLE
Turn off outdated aktivitetskrav cronjob in prod

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -93,6 +93,6 @@ spec:
     - name: OUTDATED_AKTIVITETSKRAV_CUTOFF
       value: "2023-06-01"
     - name: OUTDATED_AKTIVITETSKRAV_CRONJOB_ENABLED
-      value: "true"
+      value: "false"
     - name: PUBLISH_EXPIRED_VARSEL_CRONJOB_INTERVAL_DELAY_MINUTES
       value: "360" # Hver 6. time, 60*6


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Skrur av denne cronjobben i prod siden den kjører en "tung" sql i databasen som ikke skal eller vil gi noe resultat.