### PR TITLE
IS: Added adapter to aktivitetskrav and aktivitetskrav varsel reposit…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravService.kt
@@ -14,8 +14,8 @@ import java.time.LocalDate
 import java.util.*
 
 class AktivitetskravService(
-    private val aktivitetskravRepository: AktivitetskravRepository,
-    private val aktivitetskravVarselRepository: AktivitetskravVarselRepository,
+    private val aktivitetskravRepository: IAktivitetskravRepository,
+    private val aktivitetskravVarselRepository: IAktivitetskravVarselRepository,
     private val varselPdfService: VarselPdfService,
     private val aktivitetskravVurderingProducer: AktivitetskravVurderingProducer,
     private val arenaCutoff: LocalDate,
@@ -123,7 +123,8 @@ class AktivitetskravService(
             ?.toAktivitetskrav()
 
     internal fun getAktivitetskrav(personIdent: PersonIdent, connection: Connection? = null): List<Aktivitetskrav> =
-        aktivitetskravRepository.getAktivitetskrav(personIdent = personIdent, connection = connection).map { it.toAktivitetskrav() }
+        aktivitetskravRepository.getAktivitetskrav(personIdent = personIdent, connection = connection)
+            .map { it.toAktivitetskrav() }
 
     fun getAktivitetskravAfterCutoff(personIdent: PersonIdent): List<Aktivitetskrav> =
         aktivitetskravRepository.getAktivitetskrav(personIdent = personIdent)

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/IAktivitetskravRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/IAktivitetskravRepository.kt
@@ -1,0 +1,44 @@
+package no.nav.syfo.aktivitetskrav
+
+import no.nav.syfo.aktivitetskrav.database.PAktivitetskrav
+import no.nav.syfo.aktivitetskrav.database.PAktivitetskravVurdering
+import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
+import no.nav.syfo.domain.PersonIdent
+import java.sql.Connection
+import java.time.LocalDate
+import java.util.*
+
+interface IAktivitetskravRepository {
+
+    fun getAktivitetskrav(uuid: UUID): PAktivitetskrav?
+
+    fun getAktivitetskrav(
+        personIdent: PersonIdent,
+        connection: Connection? = null,
+    ): List<PAktivitetskrav>
+
+    fun getOutdatedAktivitetskrav(
+        arenaCutoff: LocalDate,
+        outdatedCutoff: LocalDate
+    ): List<PAktivitetskrav>
+
+    fun createAktivitetskrav(
+        aktivitetskrav: Aktivitetskrav,
+        previousAktivitetskravUuid: UUID? = null,
+        referanseTilfelleBitUuid: UUID? = null,
+        connection: Connection? = null,
+    ): PAktivitetskrav
+
+    fun createAktivitetskravVurdering(
+        aktivitetskrav: Aktivitetskrav,
+        aktivitetskravVurdering: AktivitetskravVurdering,
+    ): PAktivitetskravVurdering
+
+    fun updateAktivitetskravStatus(aktivitetskrav: Aktivitetskrav): PAktivitetskrav
+
+    fun updateAktivitetskravPersonIdent(
+        nyPersonIdent: PersonIdent,
+        inactiveIdenter: List<PersonIdent>,
+    ): Int
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/IAktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/IAktivitetskravVarselRepository.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.aktivitetskrav
+
+import no.nav.syfo.aktivitetskrav.database.PAktivitetskravVarsel
+import no.nav.syfo.aktivitetskrav.database.VarselReferences
+import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVarsel
+import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
+import no.nav.syfo.aktivitetskrav.kafka.domain.ExpiredVarsel
+import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVarsel
+import no.nav.syfo.domain.PersonIdent
+import java.util.*
+
+interface IAktivitetskravVarselRepository {
+
+    fun createAktivitetskravVurderingWithVarselPdf(
+        aktivitetskrav: Aktivitetskrav,
+        newVurdering: AktivitetskravVurdering,
+        varsel: AktivitetskravVarsel,
+        pdf: ByteArray,
+    ): PAktivitetskravVarsel
+
+    fun getIkkeJournalforte(): List<Triple<PersonIdent, PAktivitetskravVarsel, ByteArray>>
+
+    fun getIkkePubliserte(): List<Pair<PAktivitetskravVarsel, VarselReferences>>
+
+    fun updateJournalpostId(varsel: AktivitetskravVarsel, journalpostId: String)
+
+    fun setPublished(varsel: KafkaAktivitetskravVarsel)
+
+    fun getVarselForVurdering(vurderingUuid: UUID): PAktivitetskravVarsel?
+
+    suspend fun getExpiredVarsler(): List<Triple<PersonIdent, UUID, PAktivitetskravVarsel>>
+
+    suspend fun updateExpiredVarselPublishedAt(publishedExpiredVarsel: ExpiredVarsel): Int
+}

--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/database/AktivitetskravVarselRepository.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.aktivitetskrav.IAktivitetskravVarselRepository
 import no.nav.syfo.aktivitetskrav.domain.Aktivitetskrav
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVarsel
 import no.nav.syfo.aktivitetskrav.domain.AktivitetskravVurdering
@@ -22,9 +23,9 @@ import java.util.*
 
 private val mapper = configuredJacksonMapper()
 
-class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
+class AktivitetskravVarselRepository(private val database: DatabaseInterface) : IAktivitetskravVarselRepository {
 
-    fun createAktivitetskravVurderingWithVarselPdf(
+    override fun createAktivitetskravVurderingWithVarselPdf(
         aktivitetskrav: Aktivitetskrav,
         newVurdering: AktivitetskravVurdering,
         varsel: AktivitetskravVarsel,
@@ -48,21 +49,22 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
             nyttVarsel
         }
 
-    fun getIkkeJournalforte(): List<Triple<PersonIdent, PAktivitetskravVarsel, ByteArray>> =
+    override fun getIkkeJournalforte(): List<Triple<PersonIdent, PAktivitetskravVarsel, ByteArray>> =
         database.getIkkeJournalforteVarsler()
 
-    fun getIkkePubliserte(): List<Pair<PAktivitetskravVarsel, VarselReferences>> =
+    override fun getIkkePubliserte(): List<Pair<PAktivitetskravVarsel, VarselReferences>> =
         database.getIkkePubliserteVarsler()
 
-    fun updateJournalpostId(varsel: AktivitetskravVarsel, journalpostId: String) =
+    override fun updateJournalpostId(varsel: AktivitetskravVarsel, journalpostId: String) =
         database.updateVarselJournalpostId(varsel, journalpostId)
 
-    fun setPublished(varsel: KafkaAktivitetskravVarsel) =
+    override fun setPublished(varsel: KafkaAktivitetskravVarsel) =
         database.setPublished(varsel.varselUuid)
 
-    fun getVarselForVurdering(vurderingUuid: UUID) = database.getVarselForVurdering(vurderingUuid = vurderingUuid)
+    override fun getVarselForVurdering(vurderingUuid: UUID) =
+        database.getVarselForVurdering(vurderingUuid = vurderingUuid)
 
-    suspend fun getExpiredVarsler(): List<Triple<PersonIdent, UUID, PAktivitetskravVarsel>> =
+    override suspend fun getExpiredVarsler(): List<Triple<PersonIdent, UUID, PAktivitetskravVarsel>> =
         withContext(Dispatchers.IO) {
             database.connection.use { connection ->
                 connection.prepareStatement(SELECT_EXPIRED_VARSLER)
@@ -79,7 +81,7 @@ class AktivitetskravVarselRepository(private val database: DatabaseInterface) {
             }
         }
 
-    suspend fun updateExpiredVarselPublishedAt(
+    override suspend fun updateExpiredVarselPublishedAt(
         publishedExpiredVarsel: ExpiredVarsel
     ): Int =
         withContext(Dispatchers.IO) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til adaptere til `AktivitetskravVarselRepository` og `AktivitetskravRepository`.
- "Ports and adapters" er et mye brukt pattern når man vil holde domenelogikk adskilt fra verden utenfor. Ved å legge til disse `interface`'ene får vi en tydelig kontrakt rundt hva applikasjonslaget trenger fra en lagringsfunksjon. Så lenge vi oppfyller kontrakten som står i interfacene `IAktivitetskravVarselRepository` eller `IAktivitetskravRepository` så kan vi bytte ut implementasjonen. Applikasjonslaget mottar heller ikke lenger implementasjonen, men bare kontrakten. Dette gjør at skillet mellom domenelogikk og lagringslogikk blir tydeligere.

Tar gjerne i mot kommentarer på hva dere tenker om å bruke dette patternet 😊