### PR TITLE
S-1938: Subtract one day from stoppunkt date

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/Aktivitetskrav.kt
@@ -68,7 +68,7 @@ data class Aktivitetskrav(
         )
 
         fun stoppunktDato(tilfelleStart: LocalDate): LocalDate =
-            tilfelleStart.plusWeeks(AKTIVITETSKRAV_STOPPUNKT_WEEKS)
+            tilfelleStart.plusWeeks(AKTIVITETSKRAV_STOPPUNKT_WEEKS).minusDays(1)
     }
 }
 

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -59,7 +59,7 @@ class AktivitetskravSpek : Spek({
 
             val updatedAktivitetskrav = aktivitetskrav.updateStoppunkt(oppfolgingstilfelle = oppfolgingstilfelle)
 
-            updatedAktivitetskrav.stoppunktAt shouldBeEqualTo nineWeeksAgo.plusWeeks(8)
+            updatedAktivitetskrav.stoppunktAt shouldBeEqualTo nineWeeksAgo.plusWeeks(8).minusDays(1)
         }
     }
 

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -14,18 +14,13 @@ import no.nav.syfo.aktivitetskrav.domain.*
 import no.nav.syfo.aktivitetskrav.kafka.AktivitetskravVurderingProducer
 import no.nav.syfo.aktivitetskrav.kafka.domain.KafkaAktivitetskravVurdering
 import no.nav.syfo.testhelper.*
-import no.nav.syfo.testhelper.generator.createAktivitetskravAutomatiskOppfylt
-import no.nav.syfo.testhelper.generator.createAktivitetskravNy
-import no.nav.syfo.testhelper.generator.createAktivitetskravUnntak
-import no.nav.syfo.testhelper.generator.generateDocumentComponentDTO
+import no.nav.syfo.testhelper.generator.*
 import no.nav.syfo.util.*
 import org.amshove.kluent.*
-import org.apache.kafka.clients.producer.KafkaProducer
-import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.clients.producer.RecordMetadata
+import org.apache.kafka.clients.producer.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
-import java.time.LocalDate
+import java.time.*
 import java.util.*
 import java.util.concurrent.Future
 
@@ -399,7 +394,11 @@ class AktivitetskravApiSpek : Spek({
                     it("Returns historikk when aktivitetskrav has status NY_VURDERING") {
                         aktivitetskravRepository.createAktivitetskrav(
                             nyAktivitetskrav.copy(
-                                createdAt = nowUTC().minusWeeks(2) // createdAt same date as stoppunkt
+                                createdAt = OffsetDateTime.of(
+                                    nyAktivitetskrav.stoppunktAt,
+                                    LocalTime.MIDNIGHT,
+                                    ZoneOffset.UTC
+                                ) // createdAt same date as stoppunkt
                             )
                         )
                         with(

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/cronjob/OutdatedAktivitetskravCronjobSpek.kt
@@ -56,7 +56,7 @@ class OutdatedAktivitetskravCronjobSpek : Spek({
 
     fun createNyttAktivitetskrav(stoppunktAt: LocalDate): Aktivitetskrav = Aktivitetskrav.create(
         personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
-        oppfolgingstilfelleStart = stoppunktAt.minusWeeks(8),
+        oppfolgingstilfelleStart = stoppunktAt.minusWeeks(8).plusDays(1),
     )
 
     describe("${OutdatedAktivitetskravCronjob::class.java.simpleName}: run job") {


### PR DESCRIPTION
The first given date is not counted when adding weeks, but when we calculate duration of tilfelle it is.
When tilfelle is exactly 56 days long, stoppunkt will be after the tilfelle end date.
This causes us to make a new aktivitetskrav when we get an updated tilfelle on kafka with the same end date.
This change makes the stoppunkt date count the first date of the tilfelle like we do when calculating the tilfelle length.