### PR TITLE
IS-1938: change some stoppunkt to one day earlier

### DIFF
--- a/src/main/resources/db/migration/V4_0__fix_stoppunkt.sql
+++ b/src/main/resources/db/migration/V4_0__fix_stoppunkt.sql
@@ -1,0 +1,3 @@
+UPDATE aktivitetskrav
+SET stoppunkt_at = stoppunkt_at - INTERVAL '1 day', updated_at = now()
+WHERE created_at > '2023-12-07' AND referanse_tilfelle_bit_uuid IS NOT NULL AND status != 'AUTOMATISK_OPPFYLT';


### PR DESCRIPTION
See https://github.com/navikt/isaktivitetskrav/pull/194
This will change all stoppunkt created after we added "antallSykedager" so they align with how we calculate tilfelle duration.
Now they will also be the same as new aktivitetskrav will be with the previously added stoppunkt logic.
Now we avoid creating even more aktivitetskrav for updated tilfeller with same duration.