### PR TITLE
IS-1943: remove illegal chars from document component texts before pdgen

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/DocumentComponentDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/api/DocumentComponentDTO.kt
@@ -5,7 +5,21 @@ data class DocumentComponentDTO(
     val key: String? = null,
     val title: String?,
     val texts: List<String>,
-)
+) {
+    companion object {
+        internal val illegalCharacters = listOf('\u0002')
+    }
+}
+
+fun List<DocumentComponentDTO>.sanitizeForPdfGen(): List<DocumentComponentDTO> = this.map {
+    it.copy(
+        texts = it.texts.map { text ->
+            text.toCharArray()
+                .filter { char -> char !in DocumentComponentDTO.illegalCharacters }
+                .joinToString("")
+        }
+    )
+}
 
 enum class DocumentComponentType {
     HEADER_H1,

--- a/src/main/kotlin/no/nav/syfo/client/pdfgen/ForhandsvarselPdfDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdfgen/ForhandsvarselPdfDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.client.pdfgen
 
 import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.aktivitetskrav.api.sanitizeForPdfGen
 import no.nav.syfo.domain.PersonIdent
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -24,7 +25,7 @@ data class ForhandsvarselPdfDTO private constructor(
                 mottakerNavn = mottakerNavn,
                 mottakerFodselsnummer = mottakerPersonIdent.value,
                 datoSendt = LocalDate.now().format(formatter),
-                documentComponents = documentComponents
+                documentComponents = documentComponents.sanitizeForPdfGen()
             )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/pdfgen/VurderingPdfDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/client/pdfgen/VurderingPdfDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.client.pdfgen
 
 import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.aktivitetskrav.api.sanitizeForPdfGen
 import java.util.*
 
 data class VurderingPdfDTO private constructor(
@@ -11,7 +12,7 @@ data class VurderingPdfDTO private constructor(
             documentComponents: List<DocumentComponentDTO>
         ): VurderingPdfDTO =
             VurderingPdfDTO(
-                documentComponents = documentComponents
+                documentComponents = documentComponents.sanitizeForPdfGen()
             )
     }
 }

--- a/src/test/kotlin/no/nav/syfo/client/pdfgen/ForhandsvarselPdfDTOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdfgen/ForhandsvarselPdfDTOSpek.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.client.pdfgen
+
+import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.aktivitetskrav.api.DocumentComponentType
+import no.nav.syfo.testhelper.UserConstants
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class ForhandsvarselPdfDTOSpek : Spek({
+
+    val documentWithIllegalChar = listOf(
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = "tittel",
+            texts = listOf("text1\u0002dsa", "text2"),
+        )
+    )
+    val expectedDocument = listOf(
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = "tittel",
+            texts = listOf("text1dsa", "text2"),
+        )
+    )
+
+    describe(ForhandsvarselPdfDTO::class.java.simpleName) {
+        it("creates dto with illegal characters removed") {
+            val forhandsvarselPdfDTO =
+                ForhandsvarselPdfDTO.create(
+                    mottakerNavn = "navn",
+                    mottakerPersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+                    documentComponents = documentWithIllegalChar
+                )
+
+            forhandsvarselPdfDTO.documentComponents shouldBeEqualTo expectedDocument
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/client/pdfgen/PdfGenClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdfgen/PdfGenClientSpek.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.client.pdfgen
 
 import kotlinx.coroutines.runBlocking
-import no.nav.syfo.client.pdl.PdlClient
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import org.amshove.kluent.shouldBeEqualTo
@@ -12,7 +11,7 @@ class PdfGenClientSpek : Spek({
     val externalMockEnvironment = ExternalMockEnvironment.instance
     val pdfGenClient = externalMockEnvironment.pdfgenClient
 
-    describe("${PdlClient::class.java.simpleName}: navn") {
+    describe("${PdfGenClient::class.java.simpleName}: navn") {
         it("returns bytearray of pdf for forhandsvarsel") {
             val forhandsvarselPdfDTO = ForhandsvarselPdfDTO.create(
                 mottakerNavn = UserConstants.PERSON_FULLNAME,

--- a/src/test/kotlin/no/nav/syfo/client/pdfgen/VurderingPdfDTOSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/pdfgen/VurderingPdfDTOSpek.kt
@@ -1,0 +1,33 @@
+package no.nav.syfo.client.pdfgen
+
+import no.nav.syfo.aktivitetskrav.api.DocumentComponentDTO
+import no.nav.syfo.aktivitetskrav.api.DocumentComponentType
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class VurderingPdfDTOSpek : Spek({
+
+    val documentWithIllegalChar = listOf(
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = "tittel",
+            texts = listOf("text1\u0002dsa", "text2"),
+        )
+    )
+    val expectedDocument = listOf(
+        DocumentComponentDTO(
+            type = DocumentComponentType.PARAGRAPH,
+            title = "tittel",
+            texts = listOf("text1dsa", "text2"),
+        )
+    )
+
+    describe(VurderingPdfDTO::class.java.simpleName) {
+        it("creates dto with illegal characters removed") {
+            val vurderingPdfDTO = VurderingPdfDTO.create(documentWithIllegalChar)
+
+            vurderingPdfDTO.documentComponents shouldBeEqualTo expectedDocument
+        }
+    }
+})


### PR DESCRIPTION
Lagt til tilsvarende håndtering vi har i andre apper for å filtrere ut ulovlig tegn fra document-component-text før pdf-generering.