### PR TITLE
IS-2018: Delete vurdering

### DIFF
--- a/src/main/resources/db/migration/V4_2__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V4_2__delete_wrong_vurdering.sql
@@ -1,0 +1,1 @@
+DELETE FROM aktivitetskrav_vurdering WHERE uuid = '49db7eca-96e8-4c93-b3e8-189be5017c33';


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Sletter feilregistrert unntak på person. Veileder har startet ny vurdering i etterkant så tror ikke det trengs noen oppdatering av aktivitetskravet eller sletting på eSyfo sin side.