### PR TITLE
Log uuids when sending to kafka fails

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/aktivitetskrav/kafka/AktivitetskravVurderingProducer.kt
@@ -49,8 +49,10 @@ class AktivitetskravVurderingProducer(
             }
         } catch (e: Exception) {
             log.error(
-                "Exception was thrown when attempting to send KafkaAktivitetskravVurdering with id {}: ${e.message}",
-                key
+                "Exception was thrown when attempting to send KafkaAktivitetskravVurdering with key: {}, aktivitetskravUUID: {}, vurderingUUID: {}, ${e.message}",
+                key,
+                kafkaAktivitetskravVurdering.uuid,
+                kafkaAktivitetskravVurdering.sisteVurderingUuid,
             )
             throw e
         }


### PR DESCRIPTION
Nøkkelen vi logger i dag lagres ikke i databasen, så det er vanskelig å finne det som feilet.
Derfor logger vi nå også uuid for aktivitetskravet og siste vurdering.