### PR TITLE
IS-2267: Handle 409 from dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClient.kt
@@ -39,8 +39,15 @@ class DokarkivClient(
             COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS.increment()
             journalpostResponse
         } catch (e: ClientRequestException) {
-            handleUnexpectedResponseException(e.response, e.message)
-            throw e
+            if (e.response.status == HttpStatusCode.Conflict) {
+                val journalpostResponse = e.response.body<JournalpostResponse>()
+                log.warn("Journalpost med id ${journalpostResponse.journalpostId} lagret fra før (409 Conflict)")
+                COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT.increment()
+                journalpostResponse
+            } else {
+                handleUnexpectedResponseException(e.response, e.message)
+                throw e
+            }
         } catch (e: ServerResponseException) {
             handleUnexpectedResponseException(e.response, e.message)
             throw e

--- a/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/dokarkiv/DokarkivMetric.kt
@@ -9,6 +9,7 @@ const val CALL_DOKARKIV_BASE = "${METRICS_NS}_call_dokarkiv"
 const val CALL_DOKARKIV_JOURNALPOST_BASE = "${CALL_DOKARKIV_BASE}_journalpost"
 const val CALL_DOKARKIV_JOURNALPOST_SUCCESS = "${CALL_DOKARKIV_JOURNALPOST_BASE}_success_count"
 const val CALL_DOKARKIV_JOURNALPOST_FAIL = "${CALL_DOKARKIV_JOURNALPOST_BASE}_fail_count"
+const val CALL_DOKARKIV_JOURNALPOST_CONFLICT = "${CALL_DOKARKIV_JOURNALPOST_BASE}_conflict_count"
 
 val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
     .builder(CALL_DOKARKIV_JOURNALPOST_SUCCESS)
@@ -17,4 +18,8 @@ val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
 val COUNT_CALL_DOKARKIV_JOURNALPOST_FAIL: Counter = Counter
     .builder(CALL_DOKARKIV_JOURNALPOST_FAIL)
     .description("Counts the number of failed calls to Dokarkiv - Journalpost")
+    .register(METRICS_REGISTRY)
+val COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT: Counter = Counter
+    .builder(CALL_DOKARKIV_JOURNALPOST_CONFLICT)
+    .description("Counts the number of calls to Dokarkiv - Journalpost resulting in 409 Conflict")
     .register(METRICS_REGISTRY)

--- a/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/dokarkiv/DokarkivClientSpek.kt
@@ -7,7 +7,7 @@ import no.nav.syfo.client.dokarkiv.domain.JournalpostType
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generator.generateJournalpostRequest
-import org.amshove.kluent.internal.assertFailsWith
+import no.nav.syfo.testhelper.mock.conflictResponse
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -40,7 +40,7 @@ class DokarkivClientSpek : Spek({
             }
         }
 
-        it("handles conflict from api when eksternRefeanseId exists") {
+        it("handles conflict from api when eksternRefeanseId exists, and uses the existing journalpostId") {
             val journalpostRequestForhandsvarsel = generateJournalpostRequest(
                 tittel = "Forhåndsvarsel om stans av sykepenger",
                 brevkodeType = BrevkodeType.AKTIVITETSKRAV_FORHANDSVARSEL,
@@ -49,10 +49,12 @@ class DokarkivClientSpek : Spek({
                 journalpostType = JournalpostType.UTGAAENDE.name,
             )
 
-            assertFailsWith<ClientRequestException> {
-                runBlocking {
+            runBlocking {
+                val journalpostResponse =
                     dokarkivClient.journalfor(journalpostRequest = journalpostRequestForhandsvarsel)
-                }
+
+                journalpostResponse.journalpostId shouldBeEqualTo conflictResponse.journalpostId
+                journalpostResponse.journalstatus shouldBeEqualTo conflictResponse.journalstatus
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/DokarkivMock.kt
@@ -12,13 +12,18 @@ val response = JournalpostResponse(
     journalpostferdigstilt = true,
     journalstatus = "status",
 )
+val conflictResponse = JournalpostResponse(
+    journalpostId = 2,
+    journalpostferdigstilt = true,
+    journalstatus = "conflict",
+)
 
 suspend fun MockRequestHandleScope.dokarkivMockResponse(request: HttpRequestData): HttpResponseData {
     val journalpostRequest = request.receiveBody<JournalpostRequest>()
     val eksternReferanseId = journalpostRequest.eksternReferanseId
 
     return when (eksternReferanseId) {
-        UserConstants.EXISTING_EKSTERN_REFERANSE_UUID.toString() -> respondError(HttpStatusCode.Conflict)
+        UserConstants.EXISTING_EKSTERN_REFERANSE_UUID.toString() -> respond(conflictResponse, HttpStatusCode.Conflict)
         else -> respond(response)
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockUtils.kt
@@ -7,10 +7,10 @@ import no.nav.syfo.util.configuredJacksonMapper
 
 val mapper = configuredJacksonMapper()
 
-fun <T> MockRequestHandleScope.respond(body: T): HttpResponseData =
+fun <T> MockRequestHandleScope.respond(body: T, statusCode: HttpStatusCode = HttpStatusCode.OK): HttpResponseData =
     respond(
         mapper.writeValueAsString(body),
-        HttpStatusCode.OK,
+        statusCode,
         headersOf(HttpHeaders.ContentType, "application/json")
     )
 


### PR DESCRIPTION
409 fra Dokarkiv betyr at journalpost allerede er opprettet og vi kan håndtere dette ved å lagre journalpostIden vi får fra responsen.