### PR TITLE
IS-2596: Do not update aktivitetskrav with stoppunkt before arena cutoff

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/Aktivitetskrav.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Aktivitetskrav.kt
@@ -85,9 +85,9 @@ fun Aktivitetskrav.isNy(): Boolean = this.status == AktivitetskravStatus.NY
 
 fun Aktivitetskrav.isInFinalState() = this.status.isFinal
 
-internal fun Aktivitetskrav.shouldUpdateStoppunkt(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean {
+internal fun Aktivitetskrav.shouldUpdateStoppunkt(oppfolgingstilfelle: Oppfolgingstilfelle, arenaCutoff: LocalDate): Boolean {
     val updatedStoppunktDato = Aktivitetskrav.stoppunktDato(oppfolgingstilfelle.tilfelleStart)
-    return this.stoppunktAt != updatedStoppunktDato
+    return updatedStoppunktDato.isAfter(arenaCutoff) && this.stoppunktAt != updatedStoppunktDato
 }
 
 internal fun Aktivitetskrav.updateStoppunkt(oppfolgingstilfelle: Oppfolgingstilfelle): Aktivitetskrav {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -100,7 +100,11 @@ class KafkaOppfolgingstilfellePersonService(
                 log.info("Found aktivitetskrav AUTOMATISK_OPPFYLT but Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid} not gradert - creating aktivitetskrav")
                 createAktivitetskrav(connection = connection, oppfolgingstilfelle = latestOppfolgingstilfelle)
                 COUNT_KAFKA_CONSUMER_OPPFOLGINGSTILFELLE_PERSON_AKTIVITETSKRAV_CREATED.increment()
-            } else if (latestAktivitetskravForTilfelle.shouldUpdateStoppunkt(latestOppfolgingstilfelle)) {
+            } else if (latestAktivitetskravForTilfelle.shouldUpdateStoppunkt(
+                    oppfolgingstilfelle = latestOppfolgingstilfelle,
+                    arenaCutoff = arenaCutoff
+                )
+            ) {
                 log.info("Updating stoppunkt for aktivitetskrav for Oppfolgingstilfelle with uuid ${latestOppfolgingstilfelle.uuid}")
                 aktivitetskravService.updateAktivitetskravStoppunkt(
                     connection = connection,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/AktivitetskravSpek.kt
@@ -53,6 +53,30 @@ class AktivitetskravSpek : Spek({
         }
     }
 
+    describe("shouldUpdateStoppunkt") {
+        it("true if stoppunkt changed and after arenaCutoff") {
+            val aktivitetskrav = createAktivitetskravNy(tilfelleStart = tenWeeksAgo)
+            val shouldUpdate = aktivitetskrav.shouldUpdateStoppunkt(oppfolgingstilfelle = oppfolgingstilfelle, arenaCutoff = LocalDate.now().minusWeeks(4))
+
+            shouldUpdate shouldBeEqualTo true
+        }
+        it("false if stoppunkt is unchanged") {
+            val aktivitetskrav = createAktivitetskravNy(tilfelleStart = tenWeeksAgo)
+            val shouldUpdate = aktivitetskrav.shouldUpdateStoppunkt(
+                oppfolgingstilfelle = oppfolgingstilfelle.copy(tilfelleStart = tenWeeksAgo,),
+                arenaCutoff = LocalDate.now().minusWeeks(4)
+            )
+
+            shouldUpdate shouldBeEqualTo false
+        }
+        it("false if stoppunkt before arenaCutoff") {
+            val aktivitetskrav = createAktivitetskravNy(tilfelleStart = tenWeeksAgo)
+            val shouldUpdate = aktivitetskrav.shouldUpdateStoppunkt(oppfolgingstilfelle = oppfolgingstilfelle, arenaCutoff = LocalDate.now())
+
+            shouldUpdate shouldBeEqualTo false
+        }
+    }
+
     describe("updateStoppunkt") {
         it("updates stoppunktAt") {
             val aktivitetskrav = createAktivitetskravNy(tilfelleStart = tenWeeksAgo)


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fikset bug som gjorde at vi oppdaterte gamle aktivitetskrav med stoppunkt-dato før Arena-cutoff (disse skal ha blitt vurdert i Arena og skal ikke dukke opp i Modia). 
Oppdateringen ble sendt på Kafka og førte til at personen ble satt til aktiv i oversikten. 

Fant 293 tilfeller i oversikten hvor det nye flagget `is_aktiv_aktivitetskrav_vurdering` var satt til `true`, men personen skulle ikke ha hatt aktivt aktivitetskrav basert på logikken for de "gamle" feltene. Retter opp disse når vi migrerer aktivitetskrav-dataene i oversikten.