### PR TITLE
IS-2658: Do not generate aktivitetskrav for inactive tilfelle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kotlin.code.style=official
+kotlin.daemon.jvmargs=-Xmx1024m

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -2,11 +2,11 @@ package no.nav.syfo.oppfolgingstilfelle.domain
 
 import no.nav.syfo.domain.AKTIVITETSKRAV_STOPPUNKT_WEEKS
 import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.util.isMoreThanDaysAgo
 import java.time.*
 import java.time.temporal.ChronoUnit
 import java.util.*
 
-const val ARBEIDSGIVERPERIODE_DAYS = 16L
 private const val DAYS_IN_WEEK = 7
 
 data class Oppfolgingstilfelle(
@@ -28,8 +28,7 @@ fun Oppfolgingstilfelle.passererAktivitetskravStoppunkt(): Boolean =
 
 fun Oppfolgingstilfelle.isGradertAtTilfelleEnd(): Boolean = this.gradertAtTilfelleEnd == true
 
-fun Oppfolgingstilfelle.isInactive(): Boolean =
-    LocalDate.now().isAfter(this.tilfelleEnd.plusDays(ARBEIDSGIVERPERIODE_DAYS))
+fun Oppfolgingstilfelle.isInactive(): Boolean = this.tilfelleEnd isMoreThanDaysAgo 30
 
 fun Oppfolgingstilfelle.durationInWeeks(): Long {
     val durationInDays = if (this.antallSykedager != null) {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/domain/Oppfolgingstilfelle.kt
@@ -6,6 +6,7 @@ import java.time.*
 import java.time.temporal.ChronoUnit
 import java.util.*
 
+const val ARBEIDSGIVERPERIODE_DAYS = 16L
 private const val DAYS_IN_WEEK = 7
 
 data class Oppfolgingstilfelle(
@@ -26,6 +27,9 @@ fun Oppfolgingstilfelle.passererAktivitetskravStoppunkt(): Boolean =
     durationInWeeks() >= AKTIVITETSKRAV_STOPPUNKT_WEEKS
 
 fun Oppfolgingstilfelle.isGradertAtTilfelleEnd(): Boolean = this.gradertAtTilfelleEnd == true
+
+fun Oppfolgingstilfelle.isInactive(): Boolean =
+    LocalDate.now().isAfter(this.tilfelleEnd.plusDays(ARBEIDSGIVERPERIODE_DAYS))
 
 fun Oppfolgingstilfelle.durationInWeeks(): Long {
     val durationInDays = if (this.antallSykedager != null) {

--- a/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
+++ b/src/main/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonService.kt
@@ -138,7 +138,7 @@ class KafkaOppfolgingstilfellePersonService(
     private fun notRelevantForAktivitetskrav(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean =
         !oppfolgingstilfelle.passererAktivitetskravStoppunkt() || oppfolgingstilfelle.dodsdato != null || oppfolgingstilfelle.tilfelleStart.isBefore(
             OLD_TILFELLE_CUTOFF
-        ) || oppfolgingstilfelle.tilfelleEnd.isBefore(arenaCutoff)
+        ) || oppfolgingstilfelle.isInactive()
 
     companion object {
         private val log = LoggerFactory.getLogger(KafkaOppfolgingstilfellePersonService::class.java)

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -14,3 +14,5 @@ fun OffsetDateTime.millisekundOpplosning(): OffsetDateTime = this.truncatedTo(Ch
 fun OffsetDateTime.sekundOpplosning(): OffsetDateTime = this.truncatedTo(ChronoUnit.SECONDS)
 
 fun LocalDate.isAfterOrEqual(date: LocalDate) = !this.isBefore(date)
+
+infix fun LocalDate.isMoreThanDaysAgo(days: Long): Boolean = this.isBefore(LocalDate.now().minusDays(days))

--- a/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/oppfolgingstilfelle/kafka/KafkaOppfolgingstilfellePersonServiceSpek.kt
@@ -868,7 +868,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
 
             describe("Inactive oppfolgingstilfelle") {
                 val startDate = LocalDate.now().minusDays(90)
-                val endDate = LocalDate.now().minusDays(17)
+                val endDate = LocalDate.now().minusDays(31)
                 val kafkaInactiveOppfolgingstilfelle = createKafkaOppfolgingstilfellePerson(
                     personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
                     tilfelleStart = startDate,
@@ -876,7 +876,7 @@ class KafkaOppfolgingstilfellePersonServiceSpek : Spek({
                     gradert = false,
                 )
 
-                it("does not create Aktivitetskrav(NY) for oppfolgingstilfelle ending more than 16 days ago") {
+                it("does not create Aktivitetskrav(NY) for oppfolgingstilfelle ending more than 30 days ago") {
                     mockKafkaConsumerOppfolgingstilfellePerson(
                         kafkaInactiveOppfolgingstilfelle
                     )


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Dersom det har gått 16 dager siden slutt-dato på tilfellet anser vi det som inaktivt og genererer ikke aktivitetskrav

Feilen funnet ifm https://jira.adeo.no/browse/FAGSYSTEM-345009:
Her ble det lest inn en person med oppfølgingstilfeller hvor det nyeste tilfellet startet i fremtiden. Dette ble filtrert bort og vi sjekket om det forrige oppfølgingstilfellet (med `fom` 6/8-2023 - `tom` 30/9-2023) skal generere aktivitetskrav. Siden dette hadde `antallSykedager = 56` (>= 8 uker) genererte det nytt aktivitetskrav selv om tilfellet ble avsluttet 30/9-2023.
Grunnen til at dette tilfellet ikke genererte aktivitetskrav ved tidligere innlesing er at vi har endret til å sjekke `antallSykedager` i stedet for antall dager mellom `fom` og `tom` (som i dette tilfellet ble 55 og < 8 uker)