### PR TITLE
IS-2724: Delete wrong unntak

### DIFF
--- a/src/main/resources/db/migration/V5_3__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V5_3__delete_wrong_vurdering.sql
@@ -1,0 +1,8 @@
+DELETE
+FROM aktivitetskrav_vurdering
+WHERE uuid = '40bdedc6-8246-468b-87cf-936faba7981d';
+
+UPDATE aktivitetskrav
+SET status     = 'NY',
+    updated_at = now()
+where uuid = 'c218e471-2d36-486a-9162-d059ca1d8251';


### PR DESCRIPTION
Sletter feilregistrert unntak og setter aktivitetskravet tilbake til status NY. Videre må veileder gjør ny vurdering for at det skal bli riktig i oversikten og hos eSyfo.

Ref: https://jira.adeo.no/browse/FAGSYSTEM-349036