### PR TITLE
IS-2848: Respond 409 on conflict

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
@@ -65,8 +65,11 @@ fun Application.installStatusPages() {
                 is ResponseException -> {
                     cause.response.status
                 }
-                is IllegalArgumentException, is BadRequestException, is ConflictException -> {
+                is IllegalArgumentException, is BadRequestException -> {
                     HttpStatusCode.BadRequest
+                }
+                is ConflictException -> {
+                    HttpStatusCode.Conflict
                 }
                 is ForbiddenAccessVeilederException -> {
                     HttpStatusCode.Forbidden

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiForhandsvarselSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiForhandsvarselSpek.kt
@@ -170,7 +170,7 @@ class AktivitetskravApiForhandsvarselSpek : Spek({
                         response.status shouldBeEqualTo HttpStatusCode.Created
 
                         val newResponse = client.postForhandsvarsel()
-                        newResponse.status shouldBeEqualTo HttpStatusCode.BadRequest
+                        newResponse.status shouldBeEqualTo HttpStatusCode.Conflict
                     }
                 }
                 it("Fails if already forhandsvarsel before") {
@@ -183,7 +183,7 @@ class AktivitetskravApiForhandsvarselSpek : Spek({
                         avventResponse.status shouldBeEqualTo HttpStatusCode.OK
 
                         val newResponse = client.postForhandsvarsel()
-                        newResponse.status shouldBeEqualTo HttpStatusCode.BadRequest
+                        newResponse.status shouldBeEqualTo HttpStatusCode.Conflict
                     }
                 }
                 it("Fails if already unntak") {
@@ -193,7 +193,7 @@ class AktivitetskravApiForhandsvarselSpek : Spek({
                         response.status shouldBeEqualTo HttpStatusCode.OK
 
                         val newResponse = client.postForhandsvarsel()
-                        newResponse.status shouldBeEqualTo HttpStatusCode.BadRequest
+                        newResponse.status shouldBeEqualTo HttpStatusCode.Conflict
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiSpek.kt
@@ -329,7 +329,7 @@ class AktivitetskravApiSpek : Spek({
                         response.status shouldBeEqualTo HttpStatusCode.BadRequest
                     }
                 }
-                it("returns status BadRequest if previous aktivitetskrav is not final") {
+                it("returns status Conflict if previous aktivitetskrav is not final") {
                     testApplication {
                         val client = setupApiAndClient(kafkaProducer = kafkaProducer)
 
@@ -342,7 +342,7 @@ class AktivitetskravApiSpek : Spek({
                             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                             setBody(NewAktivitetskravDTO(previousAktivitetskravUuid))
                         }
-                        response.status shouldBeEqualTo HttpStatusCode.BadRequest
+                        response.status shouldBeEqualTo HttpStatusCode.Conflict
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiVurderSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiVurderSpek.kt
@@ -297,7 +297,7 @@ class AktivitetskravApiVurderSpek : Spek({
                         response.status shouldBeEqualTo HttpStatusCode.BadRequest
                     }
                 }
-                it("returns status BadRequest if existing vurdering is final") {
+                it("returns status Conflict if existing vurdering is final") {
                     testApplication {
                         val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                         val response = client.postEndreVurdering(
@@ -310,7 +310,7 @@ class AktivitetskravApiVurderSpek : Spek({
                             aktivitetskravUuid = nyAktivitetskrav.uuid,
                             vurderingDTO = vurderingOppfyltRequestDTO,
                         )
-                        responseNew.status shouldBeEqualTo HttpStatusCode.BadRequest
+                        responseNew.status shouldBeEqualTo HttpStatusCode.Conflict
                     }
                 }
                 it("returns status BadRequest if UNNTAK is missing document") {


### PR DESCRIPTION
Dette er teknisk sett riktigere status-kode og gjør det enklere å håndtere feilen i frontend.