### PR TITLE
IS-3172: Delete wrong unntak

### DIFF
--- a/src/main/resources/db/migration/V5_8__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V5_8__delete_wrong_vurdering.sql
@@ -1,8 +1,0 @@
-DELETE
-FROM aktivitetskrav_vurdering
-WHERE uuid = '5c88df79-04b1-4214-aa74-c01b8a4e426d';
-
-UPDATE aktivitetskrav
-SET status     = 'NY',
-    updated_at = now()
-where uuid = '67212653-2d39-42ee-9bd0-69dd702b3a3e';

--- a/src/main/resources/db/migration/V5_8__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V5_8__delete_wrong_vurdering.sql
@@ -1,0 +1,8 @@
+DELETE
+FROM aktivitetskrav_vurdering
+WHERE uuid = '5c88df79-04b1-4214-aa74-c01b8a4e426d';
+
+UPDATE aktivitetskrav
+SET status     = 'NY',
+    updated_at = now()
+where uuid = '67212653-2d39-42ee-9bd0-69dd702b3a3e';

--- a/src/main/resources/db/migration/V6_2__delete_wrong_vurdering.sql
+++ b/src/main/resources/db/migration/V6_2__delete_wrong_vurdering.sql
@@ -1,0 +1,9 @@
+UPDATE aktivitetskrav
+SET previous_aktivitetskrav_uuid = NULL,
+    referanse_tilfelle_bit_uuid  = '37d3df89-b7da-40cf-9962-6e906c4a06a9'
+where uuid = '55669f85-d293-46e2-a01e-3792eaa33708';
+
+DELETE
+FROM aktivitetskrav
+WHERE uuid = '376c8aeb-7bc1-43f6-b130-4d316cbecf52';
+


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Litt usikker på hvordan dette skal håndteres.

Det som har skjedd:
- Satt opp aktivitetskrav og deretter vurdert `UNNTAK` som var feil. Har deretter startet ny aktivitetskravvurdering med riktig `AVVENT` vurdering. Lurer på om riktig løsning bare er å slette hele aktivitetskravet som har feil vurdering og flytte `previous_aktivitetskrav_uuid` og `referanse_tilfelle_bit_uuid` til det nyeste og riktige aktivitetskravet 🤔

Slik ser det ut i db👇
![Screenshot 2025-03-19 at 14 16 53](https://github.com/user-attachments/assets/f2d2570b-4bbf-4448-ae04-7eeab0083e42)


Jira-sak:
https://jira.adeo.no/browse/FAGSYSTEM-372631
