### PR TITLE
IS-3363: Bruke NAV_NO som kanal ved journalforing

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/dokarkiv/model/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/dokarkiv/model/JournalpostRequest.kt
@@ -13,6 +13,12 @@ enum class JournalpostTema(
     OPPFOLGING("OPP"),
 }
 
+enum class JournalpostKanal(
+    val value: String,
+) {
+    DITT_NAV("NAV_NO"),
+}
+
 data class JournalpostRequest(
     val avsenderMottaker: AvsenderMottaker?,
     val tittel: String,
@@ -21,6 +27,7 @@ data class JournalpostRequest(
     val journalfoerendeEnhet: Int? = JOURNALFORENDE_ENHET,
     val journalpostType: String,
     val tema: String = JournalpostTema.OPPFOLGING.value,
+    val kanal: String,
     val sak: Sak = Sak(),
     val eksternReferanseId: String,
     val overstyrInnsynsregler: String? = null,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforAktivitetskravVarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforAktivitetskravVarselCronjob.kt
@@ -117,5 +117,6 @@ fun createJournalpostRequest(
         bruker = bruker,
         dokumenter = dokumenter,
         eksternReferanseId = varsel.uuid.toString(),
+        kanal = JournalpostKanal.DITT_NAV.value,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/generator/JournalpostRequestGenerator.kt
@@ -40,4 +40,5 @@ fun generateJournalpostRequest(
     ),
     journalpostType = journalpostType,
     eksternReferanseId = varselId.toString(),
+    kanal = JournalpostKanal.DITT_NAV.value,
 )


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Setter NAV_NO som distribusjonskanal etter avklaringer med Dokarkiv.

Se https://nav-it.slack.com/archives/C012X71FN04/p1751966666446009