### PR TITLE
Check that user has "full tilgang" when trying to perform write operations.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/AktivitetskravApi.kt
@@ -68,6 +68,7 @@ fun Route.registerAktivitetskravApi(
             checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
             ) {
                 val personIdent = call.personIdent()
                 val requestDTO: NewAktivitetskravDTO? =
@@ -89,6 +90,7 @@ fun Route.registerAktivitetskravApi(
             checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
             ) {
                 val personIdent = call.personIdent()
                 val aktivitetskravUUID = UUID.fromString(call.parameters[aktivitetskravParam])
@@ -113,10 +115,12 @@ fun Route.registerAktivitetskravApi(
                 call.respond(HttpStatusCode.OK)
             }
         }
+
         post("/{$aktivitetskravParam}$forhandsvarselPath") {
             checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
             ) {
                 val aktivitetskravUUID = UUID.fromString(call.parameters[aktivitetskravParam])
                 val requestDTO = call.receive<ForhandsvarselDTO>()
@@ -135,6 +139,7 @@ fun Route.registerAktivitetskravApi(
                 call.respond(HttpStatusCode.Created, forhandsvarsel)
             }
         }
+
         post("/get-vurderinger") {
             val token = call.getBearerHeader()
                 ?: throw IllegalArgumentException("Failed to get vurderinger for personer. No Authorization header supplied.")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
@@ -2,4 +2,8 @@ package no.nav.syfo.infrastructure.client.veiledertilgang
 
 data class Tilgang(
     val erGodkjent: Boolean,
+    val erAvslatt: Boolean = false,
+    val fullTilgang: Boolean = false,
+    val finnfastlegeTilgang: Boolean = false,
+    val legacyTilgang: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -22,29 +22,40 @@ class VeilederTilgangskontrollClient(
     private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
     private val tilgangskontrollBrukereUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_BRUKERE_PATH"
 
-    suspend fun hasAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+    private suspend fun getTilgang(callId: String, personIdent: PersonIdent, token: String): Tilgang? {
         val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
             scopeClientId = clientEnvironment.clientId,
             token = token,
-        )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
+        )?.accessToken
+            ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
 
         return try {
-            val tilgang = httpClient.get(tilgangskontrollPersonUrl) {
+            val tilgangResponse = httpClient.get(tilgangskontrollPersonUrl) {
                 header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
                 header(NAV_PERSONIDENT_HEADER, personIdent.value)
                 header(NAV_CALL_ID_HEADER, callId)
                 accept(ContentType.Application.Json)
             }
             COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS.increment()
-            tilgang.body<Tilgang>().erGodkjent
+            tilgangResponse.body<Tilgang>()
         } catch (e: ResponseException) {
             if (e.response.status == HttpStatusCode.Forbidden) {
                 COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
             } else {
                 handleUnexpectedResponseException(e.response, callId)
             }
-            false
+            null
         }
+    }
+
+    suspend fun hasAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+        return getTilgang(callId, personIdent, token)?.erGodkjent ?: false
+    }
+
+    suspend fun hasWriteAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+        return getTilgang(callId, personIdent, token)?.let {
+            it.erGodkjent && it.fullTilgang
+        } ?: false
     }
 
     suspend fun veilederPersonerAccess(

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -33,6 +33,7 @@ fun ApplicationCall.getBearerHeader(): String? =
 suspend fun RoutingContext.checkVeilederTilgang(
     action: String,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+    requiresWriteAccess: Boolean = false,
     block: suspend () -> Unit,
 ) {
     val callId = call.getCallId()
@@ -41,11 +42,20 @@ suspend fun RoutingContext.checkVeilederTilgang(
     val personident = call.getPersonIdent()
         ?: throw IllegalArgumentException("Failed to $action: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
-    val hasAccess = veilederTilgangskontrollClient.hasAccess(
-        callId = callId,
-        personIdent = personident,
-        token = token,
-    )
+    val hasAccess = if (requiresWriteAccess) {
+        veilederTilgangskontrollClient.hasWriteAccess(
+            callId = callId,
+            personIdent = personident,
+            token = token,
+        )
+    } else {
+        veilederTilgangskontrollClient.hasAccess(
+            callId = callId,
+            personIdent = personident,
+            token = token,
+        )
+    }
+
     if (!hasAccess) {
         throw ForbiddenAccessVeilederException(
             action = action,

--- a/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
@@ -1,0 +1,191 @@
+package no.nav.syfo.client.veiledertilgang
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.client.ClientEnvironment
+import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.client.azuread.AzureAdToken
+import no.nav.syfo.infrastructure.client.commonConfig
+import no.nav.syfo.infrastructure.client.veiledertilgang.Tilgang
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.testhelper.mock.respond
+import no.nav.syfo.testhelper.testEnvironment
+import no.nav.syfo.util.NAV_CALL_ID_HEADER
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.bearerHeader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class VeilederTilgangskontrollClientTest {
+    private val token = "token"
+    private val oboToken = "obo-token"
+    private val callId = "call-id"
+    private val personIdent = PersonIdent("12345678910")
+    private val clientEnvironment = testEnvironment().clients.istilgangskontroll
+
+    @Test
+    fun `hasAccess returns true when tilgang is approved and sends expected headers`() {
+        val azureAdClient = mockAzureAdClientWithToken()
+        lateinit var authorizationHeader: String
+        lateinit var personidentHeader: String
+        lateinit var callIdHeader: String
+
+        // In order to inspect the headers the httpClient is called with, this test is not using the
+        // createClient() helper used by the other tests, and is instead setting up httpClient and
+        // VeilederTilgangskontrollClient manually.
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler { request ->
+                    authorizationHeader = request.headers[HttpHeaders.Authorization].orEmpty()
+                    personidentHeader = request.headers[NAV_PERSONIDENT_HEADER].orEmpty()
+                    callIdHeader = request.headers[NAV_CALL_ID_HEADER].orEmpty()
+                    respond(Tilgang(erGodkjent = true))
+                }
+            }
+        }
+
+        val client = VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = clientEnvironment,
+            httpClient = httpClient,
+        )
+
+        runBlocking {
+            assertTrue(client.hasAccess(callId, personIdent, token))
+        }
+
+        assertEquals(bearerHeader(oboToken), authorizationHeader)
+        assertEquals(personIdent.value, personidentHeader)
+        assertEquals(callId, callIdHeader)
+    }
+
+    @Test
+    fun `hasAccess returns false when tilgang is not approved`() {
+        val client = createClient(Tilgang(erGodkjent = false, fullTilgang = true))
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess returns false on forbidden response`() {
+        val client = createClient(status = HttpStatusCode.Forbidden)
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns true when tilgang to person is approved and user has fagtilgangen "full tilgang"`() {
+        val client = createClient(Tilgang(erGodkjent = true, fullTilgang = true))
+
+        runBlocking {
+            assertTrue(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns false when tilgang to person is approved but user does not have fagtilgangen "full tilgang"`() {
+        val client = createClient(Tilgang(erGodkjent = true, fullTilgang = false))
+
+        runBlocking {
+            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns false when tilgang to person is not approved`() {
+        val client = createClient(Tilgang(erGodkjent = false, fullTilgang = true))
+
+        runBlocking {
+            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns false on unexpected response`() {
+        val client = createClient(status = HttpStatusCode.InternalServerError)
+
+        runBlocking {
+            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess throws when obo token request fails`() {
+        val azureAdClient = mockk<AzureAdClient>()
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)
+        } returns null
+
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler { respond(Tilgang(erGodkjent = true)) }
+            }
+        }
+
+        val client = VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = clientEnvironment,
+            httpClient = httpClient,
+        )
+
+        assertThrows(RuntimeException::class.java) {
+            runBlocking {
+                client.hasAccess(callId, personIdent, token)
+            }
+        }
+    }
+
+    private fun createClient(
+        tilgang: Tilgang = Tilgang(erGodkjent = true),
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): VeilederTilgangskontrollClient {
+        val azureAdClient = mockAzureAdClientWithToken()
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler {
+                    if (status == HttpStatusCode.OK) {
+                        respond(tilgang, status)
+                    } else {
+                        respondError(status)
+                    }
+                }
+            }
+        }
+
+        return VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = clientEnvironment,
+            httpClient = httpClient,
+        )
+    }
+
+    private fun mockAzureAdClientWithToken(): AzureAdClient {
+        val azureAdClient = mockk<AzureAdClient>()
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)
+        } returns AzureAdToken(
+            accessToken = oboToken,
+            expires = LocalDateTime.now().plusHours(1),
+        )
+        return azureAdClient
+    }
+}
+

--- a/src/test/kotlin/no/nav/syfo/util/PipelineUtilTest.kt
+++ b/src/test/kotlin/no/nav/syfo/util/PipelineUtilTest.kt
@@ -1,0 +1,191 @@
+package no.nav.syfo.util
+
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.server.routing.RoutingCall
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.RoutingRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.api.exception.ForbiddenAccessVeilederException
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PipelineUtilTest {
+    private val action = "read aktivitetskrav"
+    private val callId = "123"
+    private val personIdent = PersonIdent("12345678910")
+    private val token = "token"
+
+    private val veilederTilgangskontrollClient = mockk<VeilederTilgangskontrollClient>()
+
+    @Test
+    fun `calls hasAccess and executes block when read access is granted`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+        var blockCalled = false
+
+        coEvery {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        } returns true
+
+        runBlocking {
+            routingContext.checkVeilederTilgang(
+                action = action,
+                veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+            ) {
+                blockCalled = true
+            }
+        }
+
+        assertTrue(blockCalled)
+        coVerify(exactly = 1) {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasWriteAccess(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `calls hasWriteAccess and executes block when write access is granted`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+        var blockCalled = false
+
+        coEvery {
+            veilederTilgangskontrollClient.hasWriteAccess(callId, personIdent, token)
+        } returns true
+
+        runBlocking {
+            routingContext.checkVeilederTilgang(
+                action = action,
+                veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
+            ) {
+                blockCalled = true
+            }
+        }
+
+        assertTrue(blockCalled)
+        coVerify(exactly = 1) {
+            veilederTilgangskontrollClient.hasWriteAccess(callId, personIdent, token)
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasAccess(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `throws forbidden and does not execute block when read access is denied`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+        var blockCalled = false
+
+        coEvery {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        } returns false
+
+        assertThrows(ForbiddenAccessVeilederException::class.java) {
+            runBlocking {
+                routingContext.checkVeilederTilgang(
+                    action = action,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                ) {
+                    blockCalled = true
+                }
+            }
+        }
+
+        assertFalse(blockCalled)
+        coVerify(exactly = 1) {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        }
+    }
+
+    @Test
+    fun `throws illegal argument when authorization header is missing`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+            }
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                routingContext.checkVeilederTilgang(
+                    action = action,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                ) {}
+            }
+        }
+
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasAccess(any(), any(), any())
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasWriteAccess(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `throws illegal argument when personident header is missing`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                routingContext.checkVeilederTilgang(
+                    action = action,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                ) {}
+            }
+        }
+
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasAccess(any(), any(), any())
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasWriteAccess(any(), any(), any())
+        }
+    }
+
+    private fun routingContextWithHeaders(headers: Headers): RoutingContext {
+        val routingRequest = mockk<RoutingRequest>()
+        every { routingRequest.headers } returns headers
+
+        val routingCall = mockk<RoutingCall>()
+        every { routingCall.request } returns routingRequest
+
+        val routingContext = mockk<RoutingContext>()
+        every { routingContext.call } returns routingCall
+        return routingContext
+    }
+}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Sjekker at bruker har "full tilgang" i følge istilgangskontroll når brukeren prøver å utføre en "skriveoperasjon", altså en handling som endrer noe.

Foreløpig har en bruker full tilgang i følge istilgangskontroll også når brukeren har dagens "legacy-tilgang", se https://github.com/navikt/istilgangskontroll/blob/e779608cc25df1b7ae49a996c0feb45f19e2afbe/src/main/kotlin/no/nav/syfo/domain/Veileder.kt#L31-L30.

VeilederTilgangskontrollClient hadde fra før en `hasAccess()`-metode som kaller istilgangskontroll og sjekker om bruker har tilgang til en person. Denne er nå skrevet litt om til en`private getTilgang()`-metode som returnerer tilgangen fra istilgangskontroll. To funksjoner, `hasAccess()` (gir lik oppførsel som tidligere funskjon med  samme navn) og `hasWriteAccess()` er lagt til som kaller `getTilgang()` for å få Tilgang-DTOen og returnerer en Boolean.

`checkVeilederTilgang()` i `PipelineUtil.kt` er endret til å ta inn en valgfri parameter `requiresWriteAccess`. Hvis den er true så sjekkes det om personen har skrivetilgang ved bruk av `hasWriteAccess`, ellers brukes `hasAccess()` som før. Se oppdaterte callsites i `AktivitetskravApi.kt`.

De nye testene er hovedsakelig KI-generert. Jeg har sett gjennom og vurdert dem nokså nøye og gjort noen justeringer.