### PR TITLE
IS-3758 Check that user has fullTilgang for write operations

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/AktivitetskravApi.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/AktivitetskravApi.kt
@@ -68,6 +68,7 @@ fun Route.registerAktivitetskravApi(
             checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
             ) {
                 val personIdent = call.personIdent()
                 val requestDTO: NewAktivitetskravDTO? =
@@ -89,6 +90,7 @@ fun Route.registerAktivitetskravApi(
             checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
             ) {
                 val personIdent = call.personIdent()
                 val aktivitetskravUUID = UUID.fromString(call.parameters[aktivitetskravParam])
@@ -113,10 +115,12 @@ fun Route.registerAktivitetskravApi(
                 call.respond(HttpStatusCode.OK)
             }
         }
+
         post("/{$aktivitetskravParam}$forhandsvarselPath") {
             checkVeilederTilgang(
                 action = API_ACTION,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
             ) {
                 val aktivitetskravUUID = UUID.fromString(call.parameters[aktivitetskravParam])
                 val requestDTO = call.receive<ForhandsvarselDTO>()
@@ -135,6 +139,7 @@ fun Route.registerAktivitetskravApi(
                 call.respond(HttpStatusCode.Created, forhandsvarsel)
             }
         }
+
         post("/get-vurderinger") {
             val token = call.getBearerHeader()
                 ?: throw IllegalArgumentException("Failed to get vurderinger for personer. No Authorization header supplied.")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
@@ -2,4 +2,8 @@ package no.nav.syfo.infrastructure.client.veiledertilgang
 
 data class Tilgang(
     val erGodkjent: Boolean,
+    val erAvslatt: Boolean = false,
+    val fullTilgang: Boolean = false,
+    val finnfastlegeTilgang: Boolean = false,
+    val legacyTilgang: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/Tilgang.kt
@@ -4,6 +4,4 @@ data class Tilgang(
     val erGodkjent: Boolean,
     val erAvslatt: Boolean = false,
     val fullTilgang: Boolean = false,
-    val finnfastlegeTilgang: Boolean = false,
-    val legacyTilgang: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/client/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -22,29 +22,40 @@ class VeilederTilgangskontrollClient(
     private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
     private val tilgangskontrollBrukereUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_BRUKERE_PATH"
 
-    suspend fun hasAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+    private suspend fun getTilgang(callId: String, personIdent: PersonIdent, token: String): Tilgang? {
         val onBehalfOfToken = azureAdClient.getOnBehalfOfToken(
             scopeClientId = clientEnvironment.clientId,
             token = token,
-        )?.accessToken ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
+        )?.accessToken
+            ?: throw RuntimeException("Failed to request access to Person: Failed to get OBO token")
 
         return try {
-            val tilgang = httpClient.get(tilgangskontrollPersonUrl) {
+            val tilgangResponse = httpClient.get(tilgangskontrollPersonUrl) {
                 header(HttpHeaders.Authorization, bearerHeader(onBehalfOfToken))
                 header(NAV_PERSONIDENT_HEADER, personIdent.value)
                 header(NAV_CALL_ID_HEADER, callId)
                 accept(ContentType.Application.Json)
             }
             COUNT_CALL_TILGANGSKONTROLL_PERSON_SUCCESS.increment()
-            tilgang.body<Tilgang>().erGodkjent
+            tilgangResponse.body<Tilgang>()
         } catch (e: ResponseException) {
             if (e.response.status == HttpStatusCode.Forbidden) {
                 COUNT_CALL_TILGANGSKONTROLL_PERSON_FORBIDDEN.increment()
             } else {
                 handleUnexpectedResponseException(e.response, callId)
             }
-            false
+            null
         }
+    }
+
+    suspend fun hasAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+        return getTilgang(callId, personIdent, token)?.erGodkjent ?: false
+    }
+
+    suspend fun hasWriteAccess(callId: String, personIdent: PersonIdent, token: String): Boolean {
+        return getTilgang(callId, personIdent, token)?.let {
+            it.erGodkjent && it.fullTilgang
+        } ?: false
     }
 
     suspend fun veilederPersonerAccess(

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -33,6 +33,7 @@ fun ApplicationCall.getBearerHeader(): String? =
 suspend fun RoutingContext.checkVeilederTilgang(
     action: String,
     veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+    requiresWriteAccess: Boolean = false,
     block: suspend () -> Unit,
 ) {
     val callId = call.getCallId()
@@ -41,11 +42,20 @@ suspend fun RoutingContext.checkVeilederTilgang(
     val personident = call.getPersonIdent()
         ?: throw IllegalArgumentException("Failed to $action: No $NAV_PERSONIDENT_HEADER supplied in request header")
 
-    val hasAccess = veilederTilgangskontrollClient.hasAccess(
-        callId = callId,
-        personIdent = personident,
-        token = token,
-    )
+    val hasAccess = if (requiresWriteAccess) {
+        veilederTilgangskontrollClient.hasWriteAccess(
+            callId = callId,
+            personIdent = personident,
+            token = token,
+        )
+    } else {
+        veilederTilgangskontrollClient.hasAccess(
+            callId = callId,
+            personIdent = personident,
+            token = token,
+        )
+    }
+
     if (!hasAccess) {
         throw ForbiddenAccessVeilederException(
             action = action,

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiForhandsvarselTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiForhandsvarselTest.kt
@@ -47,11 +47,6 @@ class AktivitetskravApiForhandsvarselTest {
     private val database = externalMockEnvironment.database
     private val kafkaProducer = mockk<KafkaProducer<String, AktivitetskravVurderingRecord>>()
     private val aktivitetskravRepository = AktivitetskravRepository(database)
-    private val validToken = generateJWT(
-        audience = externalMockEnvironment.environment.azure.appClientId,
-        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
-        navIdent = UserConstants.VEILEDER_IDENT,
-    )
     private val fritekst = "Dette er et forhåndsvarsel"
     private val svarfrist = LocalDate.now().plusDays(30)
     private val svarfristShortest = LocalDate.now().plusDays(21)
@@ -82,10 +77,11 @@ class AktivitetskravApiForhandsvarselTest {
         aktivitetskravUuid: UUID = nyAktivitetskrav.uuid,
         arbeidstakerPersonIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
         newForhandsvarselDTO: ForhandsvarselDTO = forhandsvarselDTO,
+        token: String = tokenForVeilederWithFullTilgang,
     ) = run {
         val url = "$aktivitetskravApiBasePath/$aktivitetskravUuid$forhandsvarselPath"
         post(url) {
-            bearerAuth(validToken)
+            bearerAuth(token)
             header(NAV_PERSONIDENT_HEADER, arbeidstakerPersonIdent.value)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             setBody(newForhandsvarselDTO)
@@ -95,10 +91,11 @@ class AktivitetskravApiForhandsvarselTest {
     suspend fun HttpClient.postAvvent(
         aktivitetskravUuid: UUID = nyAktivitetskrav.uuid,
         arbeidstakerPersonIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+        token: String = tokenForVeilederWithFullTilgang,
     ) = run {
         val url = "$aktivitetskravApiBasePath/$aktivitetskravUuid$vurderAktivitetskravPath"
         post(url) {
-            bearerAuth(validToken)
+            bearerAuth(token)
             header(NAV_PERSONIDENT_HEADER, arbeidstakerPersonIdent.value)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             setBody(
@@ -114,10 +111,11 @@ class AktivitetskravApiForhandsvarselTest {
     suspend fun HttpClient.postUnntak(
         aktivitetskravUuid: UUID = nyAktivitetskrav.uuid,
         arbeidstakerPersonIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+        token: String = tokenForVeilederWithFullTilgang,
     ) = run {
         val url = "$aktivitetskravApiBasePath/$aktivitetskravUuid$vurderAktivitetskravPath"
         post(url) {
-            bearerAuth(validToken)
+            bearerAuth(token)
             header(NAV_PERSONIDENT_HEADER, arbeidstakerPersonIdent.value)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             setBody(
@@ -155,7 +153,7 @@ class AktivitetskravApiForhandsvarselTest {
                     assertEquals(forhandsvarselDTO.document, createdForhandsvarsel.document)
 
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
                     }
                     assertEquals(HttpStatusCode.OK, response.status)
@@ -240,6 +238,15 @@ class AktivitetskravApiForhandsvarselTest {
                     val varselWithoutDocument = forhandsvarselDTO.copy(document = emptyList())
                     val response = client.postForhandsvarsel(newForhandsvarselDTO = varselWithoutDocument)
                     assertEquals(HttpStatusCode.BadRequest, response.status)
+                }
+            }
+
+            @Test
+            fun `Fails if user has no write access`() {
+                testApplication {
+                    val client = setupApiAndClient(kafkaProducer = kafkaProducer)
+                    val response = client.postForhandsvarsel(token = tokenForVeilederWithLeseTilgang)
+                    assertEquals(HttpStatusCode.Forbidden, response.status)
                 }
             }
 

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiTest.kt
@@ -90,12 +90,6 @@ class AktivitetskravApiTest {
         )
     )
 
-    private val validToken = generateJWT(
-        audience = externalMockEnvironment.environment.azure.appClientId,
-        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
-        navIdent = VEILEDER_IDENT,
-    )
-
     @BeforeEach
     fun setUp() {
         clearMocks(kafkaProducer)
@@ -125,7 +119,7 @@ class AktivitetskravApiTest {
                         aktivitetskravRepository.createAktivitetskrav(it)
                     }
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                     }
                     assertEquals(HttpStatusCode.OK, response.status)
@@ -185,7 +179,7 @@ class AktivitetskravApiTest {
                     }
 
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                     }
                     assertEquals(HttpStatusCode.OK, response.status)
@@ -246,7 +240,7 @@ class AktivitetskravApiTest {
                         aktivitetskravRepository.createAktivitetskrav(it)
                     }
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                     }
                     assertEquals(HttpStatusCode.OK, response.status)
@@ -261,6 +255,19 @@ class AktivitetskravApiTest {
                     assertNotNull(aktivitetskrav.createdAt)
                     assertEquals(nyAktivitetskrav.uuid, aktivitetskrav.uuid)
                     assertEquals(nyAktivitetskrav.stoppunktAt, aktivitetskrav.stoppunktAt)
+                }
+            }
+
+            @Test
+            fun `Returns status OK if user has lesetilgang`() {
+                testApplication {
+                    val client = setupApiAndClient(kafkaProducer = kafkaProducer)
+
+                    val response = client.get(urlAktivitetskravPerson) {
+                        bearerAuth(tokenForVeilederWithLeseTilgang)
+                        header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
+                    }
+                    assertEquals(HttpStatusCode.OK, response.status)
                 }
             }
         }
@@ -287,7 +294,7 @@ class AktivitetskravApiTest {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
 
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, PERSONIDENT_VEILEDER_NO_ACCESS.value)
                     }
                     assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -300,7 +307,7 @@ class AktivitetskravApiTest {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
 
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                     }
                     assertEquals(HttpStatusCode.BadRequest, response.status)
                 }
@@ -312,7 +319,7 @@ class AktivitetskravApiTest {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
 
                     val response = client.get(urlAktivitetskravPerson) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, "not-a-personident")
                     }
                     assertEquals(HttpStatusCode.BadRequest, response.status)
@@ -335,7 +342,7 @@ class AktivitetskravApiTest {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                     aktivitetskravRepository.createAktivitetskrav(unntakAktivitetskrav)
                     val response = client.post(aktivitetskravApiBasePath) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                         setBody(NewAktivitetskravDTO(unntakAktivitetskrav.uuid))
@@ -359,7 +366,7 @@ class AktivitetskravApiTest {
                 testApplication {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                     val response = client.post(aktivitetskravApiBasePath) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     }
@@ -389,17 +396,30 @@ class AktivitetskravApiTest {
 
             @Test
             fun `returns status Forbidden if denied access to person`() {
-                testDeniedPersonAccess(aktivitetskravApiBasePath, validToken, HttpMethod.Post)
+                testDeniedPersonAccess(aktivitetskravApiBasePath, tokenForVeilederWithFullTilgang, HttpMethod.Post)
+            }
+
+            @Test
+            fun `returns status Forbidden if user has no write access`() {
+                testApplication {
+                    val client = setupApiAndClient(kafkaProducer = kafkaProducer)
+                    val response = client.post(aktivitetskravApiBasePath) {
+                        bearerAuth(tokenForVeilederWithLeseTilgang)
+                        header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
+                        header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    }
+                    assertEquals(HttpStatusCode.Forbidden, response.status)
+                }
             }
 
             @Test
             fun `returns status BadRequest if personIdent is missing`() {
-                testMissingPersonIdent(aktivitetskravApiBasePath, validToken, HttpMethod.Post)
+                testMissingPersonIdent(aktivitetskravApiBasePath, tokenForVeilederWithFullTilgang, HttpMethod.Post)
             }
 
             @Test
             fun `returns status BadRequest if personIdent has invalid format`() {
-                testInvalidPersonIdent(aktivitetskravApiBasePath, validToken, HttpMethod.Post)
+                testInvalidPersonIdent(aktivitetskravApiBasePath, tokenForVeilederWithFullTilgang, HttpMethod.Post)
             }
 
             @Test
@@ -407,7 +427,7 @@ class AktivitetskravApiTest {
                 testApplication {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                     val response = client.post(aktivitetskravApiBasePath) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                         setBody(NewAktivitetskravDTO(UUID.randomUUID()))
@@ -425,7 +445,7 @@ class AktivitetskravApiTest {
                     aktivitetskravRepository.createAktivitetskrav(nyAktivitetskrav)
 
                     val response = client.post(aktivitetskravApiBasePath) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                         setBody(NewAktivitetskravDTO(previousAktivitetskravUuid))
@@ -451,7 +471,7 @@ class AktivitetskravApiTest {
                 testApplication {
                     val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                     val response = client.get(urlHistorikk) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     }
@@ -469,7 +489,7 @@ class AktivitetskravApiTest {
                     aktivitetskravRepository.createAktivitetskrav(nyAktivitetskrav)
 
                     val response = client.get(urlHistorikk) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     }
@@ -495,7 +515,7 @@ class AktivitetskravApiTest {
                         )
                     )
                     val response = client.get(urlHistorikk) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     }
@@ -527,7 +547,7 @@ class AktivitetskravApiTest {
                     }
 
                     val response = client.get(urlHistorikk) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     }
@@ -546,7 +566,7 @@ class AktivitetskravApiTest {
                     aktivitetskravRepository.createAktivitetskrav(nyAktivitetskrav)
                     aktivitetskravService.lukkAktivitetskrav(nyAktivitetskrav)
                     val response = client.get(urlHistorikk) {
-                        bearerAuth(validToken)
+                        bearerAuth(tokenForVeilederWithFullTilgang)
                         header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
                         header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     }
@@ -587,7 +607,7 @@ class AktivitetskravApiTest {
             testApplication {
                 val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                 val response = client.post("$aktivitetskravApiBasePath/get-vurderinger") {
-                    bearerAuth(validToken)
+                    bearerAuth(tokenForVeilederWithFullTilgang)
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     setBody(GetVurderingerRequestBody(listOf(ARBEIDSTAKER_PERSONIDENT.value)))
                 }
@@ -600,7 +620,7 @@ class AktivitetskravApiTest {
             testApplication {
                 val client = setupApiAndClient(kafkaProducer = kafkaProducer)
                 val response = client.post("$aktivitetskravApiBasePath/get-vurderinger") {
-                    bearerAuth(validToken)
+                    bearerAuth(tokenForVeilederWithFullTilgang)
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 }
                 assertEquals(HttpStatusCode.BadRequest, response.status)
@@ -629,7 +649,7 @@ class AktivitetskravApiTest {
                     pdf
                 )
                 val response = client.post("$aktivitetskravApiBasePath/get-vurderinger") {
-                    bearerAuth(validToken)
+                    bearerAuth(tokenForVeilederWithFullTilgang)
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     setBody(GetVurderingerRequestBody(listOf(ARBEIDSTAKER_PERSONIDENT.value)))
                 }
@@ -682,7 +702,7 @@ class AktivitetskravApiTest {
                     aktivitetskravRepository.createAktivitetskravVurdering(secondAktivitetskrav, it)
                 }
                 val response = client.post("$aktivitetskravApiBasePath/get-vurderinger") {
-                    bearerAuth(validToken)
+                    bearerAuth(tokenForVeilederWithFullTilgang)
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                     setBody(
                         GetVurderingerRequestBody(
@@ -707,7 +727,7 @@ class AktivitetskravApiTest {
     }
 
     @Test
-    fun `Only returns aktivitetskrav for persons with access`() {
+    fun `Only returns aktivitetskrav for persons that the veileder has access too`() {
         testApplication {
             val client = setupApiAndClient(kafkaProducer = kafkaProducer)
             val firstAktivitetskrav = Aktivitetskrav.create(ARBEIDSTAKER_PERSONIDENT)
@@ -719,7 +739,7 @@ class AktivitetskravApiTest {
             val personsWithAktivitetskrav =
                 listOf(ARBEIDSTAKER_PERSONIDENT.value, OTHER_ARBEIDSTAKER_PERSONIDENT.value, PERSONIDENT_VEILEDER_NO_ACCESS.value)
             val response = client.post("$aktivitetskravApiBasePath/get-vurderinger") {
-                bearerAuth(validToken)
+                bearerAuth(tokenForVeilederWithFullTilgang)
                 header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 setBody(
                     GetVurderingerRequestBody(

--- a/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiVurderTest.kt
+++ b/src/test/kotlin/no/nav/syfo/aktivitetskrav/api/AktivitetskravApiVurderTest.kt
@@ -58,11 +58,6 @@ class AktivitetskravApiVurderTest {
             pdlClient = externalMockEnvironment.pdlClient,
         )
     )
-    private val validToken = generateJWT(
-        audience = externalMockEnvironment.environment.azure.appClientId,
-        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
-        navIdent = UserConstants.VEILEDER_IDENT,
-    )
 
     @BeforeEach
     fun setUp() {
@@ -82,11 +77,12 @@ class AktivitetskravApiVurderTest {
         aktivitetskravUuid: UUID,
         vurderingDTO: AktivitetskravVurderingRequestDTO,
         personIdent: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+        token: String = tokenForVeilederWithFullTilgang,
     ): HttpResponse = run {
         val urlVurderAktivitetskrav =
             "$aktivitetskravApiBasePath/$aktivitetskravUuid$vurderAktivitetskravPath"
         post(urlVurderAktivitetskrav) {
-            bearerAuth(validToken)
+            bearerAuth(token)
             header(NAV_PERSONIDENT_HEADER, personIdent.value)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             setBody(vurderingDTO)
@@ -272,17 +268,30 @@ class AktivitetskravApiVurderTest {
 
             @Test
             fun `returns status Forbidden if denied access to person`() {
-                testDeniedPersonAccess(urlVurderExistingAktivitetskrav, validToken, HttpMethod.Post)
+                testDeniedPersonAccess(urlVurderExistingAktivitetskrav, tokenForVeilederWithFullTilgang, HttpMethod.Post)
+            }
+
+            @Test
+            fun `returns status Forbidden if user has no write access`() {
+                testApplication {
+                    val client = setupApiAndClient(kafkaProducer = kafkaProducer)
+                    val response = client.postVurdering(
+                        aktivitetskravUuid = aktivitetskravUuid,
+                        vurderingDTO = vurderingOppfyltRequestDTO,
+                        token = tokenForVeilederWithLeseTilgang,
+                    )
+                    assertEquals(HttpStatusCode.Forbidden, response.status)
+                }
             }
 
             @Test
             fun `returns status BadRequest if no NAV_PERSONIDENT_HEADER is supplied`() {
-                testMissingPersonIdent(urlVurderExistingAktivitetskrav, validToken, HttpMethod.Post)
+                testMissingPersonIdent(urlVurderExistingAktivitetskrav, tokenForVeilederWithFullTilgang, HttpMethod.Post)
             }
 
             @Test
             fun `returns status BadRequest if NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied`() {
-                testInvalidPersonIdent(urlVurderExistingAktivitetskrav, validToken, HttpMethod.Post)
+                testInvalidPersonIdent(urlVurderExistingAktivitetskrav, tokenForVeilederWithFullTilgang, HttpMethod.Post)
             }
 
             @Test

--- a/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
@@ -1,0 +1,189 @@
+package no.nav.syfo.client.veiledertilgang
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.client.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.client.azuread.AzureAdToken
+import no.nav.syfo.infrastructure.client.commonConfig
+import no.nav.syfo.infrastructure.client.veiledertilgang.Tilgang
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.testhelper.mock.respond
+import no.nav.syfo.testhelper.testEnvironment
+import no.nav.syfo.util.NAV_CALL_ID_HEADER
+import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.bearerHeader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class VeilederTilgangskontrollClientTest {
+    private val token = "token"
+    private val oboToken = "obo-token"
+    private val callId = "call-id"
+    private val personIdent = PersonIdent("12345678910")
+    private val clientEnvironment = testEnvironment().clients.istilgangskontroll
+
+    @Test
+    fun `hasAccess returns true when tilgang is approved and sends expected headers`() {
+        val azureAdClient = mockAzureAdClientWithToken()
+        lateinit var authorizationHeader: String
+        lateinit var personidentHeader: String
+        lateinit var callIdHeader: String
+
+        // In order to inspect the headers the httpClient is called with, this test is not using the
+        // createClient() helper used by the other tests, and is instead setting up httpClient and
+        // VeilederTilgangskontrollClient manually.
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler { request ->
+                    authorizationHeader = request.headers[HttpHeaders.Authorization].orEmpty()
+                    personidentHeader = request.headers[NAV_PERSONIDENT_HEADER].orEmpty()
+                    callIdHeader = request.headers[NAV_CALL_ID_HEADER].orEmpty()
+                    respond(Tilgang(erGodkjent = true))
+                }
+            }
+        }
+
+        val client = VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = clientEnvironment,
+            httpClient = httpClient,
+        )
+
+        runBlocking {
+            assertTrue(client.hasAccess(callId, personIdent, token))
+        }
+
+        assertEquals(bearerHeader(oboToken), authorizationHeader)
+        assertEquals(personIdent.value, personidentHeader)
+        assertEquals(callId, callIdHeader)
+    }
+
+    @Test
+    fun `hasAccess returns false when tilgang is not approved`() {
+        val client = createClient(Tilgang(erGodkjent = false, fullTilgang = true))
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess returns false on forbidden response`() {
+        val client = createClient(status = HttpStatusCode.Forbidden)
+
+        runBlocking {
+            assertFalse(client.hasAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns true when tilgang to person is approved and user has fullTilgang`() {
+        val client = createClient(Tilgang(erGodkjent = true, fullTilgang = true))
+
+        runBlocking {
+            assertTrue(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns false when tilgang to person is approved but user does not have fullTilgang`() {
+        val client = createClient(Tilgang(erGodkjent = true, fullTilgang = false))
+
+        runBlocking {
+            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns false when tilgang to person is not approved`() {
+        val client = createClient(Tilgang(erGodkjent = false, fullTilgang = true))
+
+        runBlocking {
+            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasWriteAccess returns false on unexpected response`() {
+        val client = createClient(status = HttpStatusCode.InternalServerError)
+
+        runBlocking {
+            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+        }
+    }
+
+    @Test
+    fun `hasAccess throws when obo token request fails`() {
+        val azureAdClient = mockk<AzureAdClient>()
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)
+        } returns null
+
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler { respond(Tilgang(erGodkjent = true)) }
+            }
+        }
+
+        val client = VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = clientEnvironment,
+            httpClient = httpClient,
+        )
+
+        assertThrows(RuntimeException::class.java) {
+            runBlocking {
+                client.hasAccess(callId, personIdent, token)
+            }
+        }
+    }
+
+    private fun createClient(
+        tilgang: Tilgang = Tilgang(erGodkjent = true),
+        status: HttpStatusCode = HttpStatusCode.OK,
+    ): VeilederTilgangskontrollClient {
+        val azureAdClient = mockAzureAdClientWithToken()
+        val httpClient = HttpClient(MockEngine) {
+            commonConfig()
+            engine {
+                addHandler {
+                    if (status == HttpStatusCode.OK) {
+                        respond(tilgang, status)
+                    } else {
+                        respondError(status)
+                    }
+                }
+            }
+        }
+
+        return VeilederTilgangskontrollClient(
+            azureAdClient = azureAdClient,
+            clientEnvironment = clientEnvironment,
+            httpClient = httpClient,
+        )
+    }
+
+    private fun mockAzureAdClientWithToken(): AzureAdClient {
+        val azureAdClient = mockk<AzureAdClient>()
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)
+        } returns AzureAdToken(
+            accessToken = oboToken,
+            expires = LocalDateTime.now().plusHours(1),
+        )
+        return azureAdClient
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
@@ -26,6 +26,10 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
+/**
+ * Unit test for VeilederTilgangControllClient. This is not full API integration testing
+ * like the API tests. azureAdClient and httpClient dependencies are mocked here.
+ */
 class VeilederTilgangskontrollClientTest {
     private val token = "token"
     private val oboToken = "obo-token"
@@ -34,15 +38,15 @@ class VeilederTilgangskontrollClientTest {
     private val clientEnvironment = testEnvironment().clients.istilgangskontroll
 
     @Test
-    fun `hasAccess returns true when tilgang is approved and sends expected headers`() {
-        val azureAdClient = mockAzureAdClientWithToken()
+    fun `hasAccess returns true when tilgang is approved and sends expected headers to istilgangskontroll`() {
+        val azureAdClient = mockAzureAdClientGetOBOToken()
         lateinit var authorizationHeader: String
         lateinit var personidentHeader: String
         lateinit var callIdHeader: String
 
-        // In order to inspect the headers the httpClient is called with, this test is not using the
-        // createClient() helper used by the other tests, and is instead setting up httpClient and
-        // VeilederTilgangskontrollClient manually.
+        // In order to intercept the headers that istilgangskontroll would be called with, this test
+        // is not using the createClient() helper used by the other tests, and is instead setting up
+        // httpClient and VeilederTilgangskontrollClient manually.
         val httpClient = HttpClient(MockEngine) {
             commonConfig()
             engine {
@@ -72,7 +76,7 @@ class VeilederTilgangskontrollClientTest {
 
     @Test
     fun `hasAccess returns false when tilgang is not approved`() {
-        val client = createClient(Tilgang(erGodkjent = false, fullTilgang = true))
+        val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
 
         runBlocking {
             assertFalse(client.hasAccess(callId, personIdent, token))
@@ -81,7 +85,7 @@ class VeilederTilgangskontrollClientTest {
 
     @Test
     fun `hasAccess returns false on forbidden response`() {
-        val client = createClient(status = HttpStatusCode.Forbidden)
+        val client = createMockClientForResponse(status = HttpStatusCode.Forbidden)
 
         runBlocking {
             assertFalse(client.hasAccess(callId, personIdent, token))
@@ -90,7 +94,7 @@ class VeilederTilgangskontrollClientTest {
 
     @Test
     fun `hasWriteAccess returns true when tilgang to person is approved and user has fullTilgang`() {
-        val client = createClient(Tilgang(erGodkjent = true, fullTilgang = true))
+        val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = true))
 
         runBlocking {
             assertTrue(client.hasWriteAccess(callId, personIdent, token))
@@ -99,7 +103,7 @@ class VeilederTilgangskontrollClientTest {
 
     @Test
     fun `hasWriteAccess returns false when tilgang to person is approved but user does not have fullTilgang`() {
-        val client = createClient(Tilgang(erGodkjent = true, fullTilgang = false))
+        val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = false))
 
         runBlocking {
             assertFalse(client.hasWriteAccess(callId, personIdent, token))
@@ -108,7 +112,7 @@ class VeilederTilgangskontrollClientTest {
 
     @Test
     fun `hasWriteAccess returns false when tilgang to person is not approved`() {
-        val client = createClient(Tilgang(erGodkjent = false, fullTilgang = true))
+        val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
 
         runBlocking {
             assertFalse(client.hasWriteAccess(callId, personIdent, token))
@@ -117,7 +121,7 @@ class VeilederTilgangskontrollClientTest {
 
     @Test
     fun `hasWriteAccess returns false on unexpected response`() {
-        val client = createClient(status = HttpStatusCode.InternalServerError)
+        val client = createMockClientForResponse(status = HttpStatusCode.InternalServerError)
 
         runBlocking {
             assertFalse(client.hasWriteAccess(callId, personIdent, token))
@@ -151,11 +155,14 @@ class VeilederTilgangskontrollClientTest {
         }
     }
 
-    private fun createClient(
+    /**
+     * Create mock veilederTilgangkontrollClient for a specific response DTO from istilgangskontroll.
+     */
+    private fun createMockClientForResponse(
         tilgang: Tilgang = Tilgang(erGodkjent = true),
         status: HttpStatusCode = HttpStatusCode.OK,
     ): VeilederTilgangskontrollClient {
-        val azureAdClient = mockAzureAdClientWithToken()
+        val azureAdClient = mockAzureAdClientGetOBOToken()
         val httpClient = HttpClient(MockEngine) {
             commonConfig()
             engine {
@@ -176,7 +183,7 @@ class VeilederTilgangskontrollClientTest {
         )
     }
 
-    private fun mockAzureAdClientWithToken(): AzureAdClient {
+    private fun mockAzureAdClientGetOBOToken(): AzureAdClient {
         val azureAdClient = mockk<AzureAdClient>()
         coEvery {
             azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -28,6 +28,7 @@ object UserConstants {
     val VIRKSOMHETSNUMMER_DEFAULT = Virksomhetsnummer(VIRKSOMHETSNUMMER)
     const val VEILEDER_IDENT = "Z999999"
     const val OTHER_VEILEDER_IDENT = "Z999998"
+    const val VEILEDER_IDENT_WITH_LESETILGANG = "Z999997"
 
     val EXISTING_EKSTERN_REFERANSE_UUID: UUID = UUID.fromString("e7e8e9e0-e1e2-e3e4-e5e6-e7e8e9e0e1e2")
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserTokens.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserTokens.kt
@@ -1,0 +1,18 @@
+package no.nav.syfo.testhelper
+
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_WITH_LESETILGANG
+
+private val externalMockEnvironment = ExternalMockEnvironment.instance
+
+val tokenForVeilederWithFullTilgang: String = generateJWT(
+    audience = externalMockEnvironment.environment.azure.appClientId,
+    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+    navIdent = VEILEDER_IDENT,
+)
+
+val tokenForVeilederWithLeseTilgang: String = generateJWT(
+    audience = externalMockEnvironment.environment.azure.appClientId,
+    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+    navIdent = VEILEDER_IDENT_WITH_LESETILGANG,
+)

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
@@ -2,12 +2,17 @@ package no.nav.syfo.testhelper.mock
 
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.client.request.forms.FormDataContent
 import no.nav.syfo.infrastructure.client.azuread.AzureAdTokenResponse
 
-fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respond(
-    AzureAdTokenResponse(
-        access_token = "token",
-        expires_in = 3600,
-        token_type = "type",
+fun MockRequestHandleScope.azureAdMockResponse(request: HttpRequestData): HttpResponseData {
+    // Echo the incoming assertion token as access token so NAVident survives OBO flow in tests.
+    val assertionToken = (request.body as? FormDataContent)?.formData?.get("assertion")
+    return respond(
+        AzureAdTokenResponse(
+            access_token = assertionToken ?: "token",
+            expires_in = 3600,
+            token_type = "type",
+        )
     )
-)
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AzureADMock.kt
@@ -6,7 +6,9 @@ import io.ktor.client.request.forms.FormDataContent
 import no.nav.syfo.infrastructure.client.azuread.AzureAdTokenResponse
 
 fun MockRequestHandleScope.azureAdMockResponse(request: HttpRequestData): HttpResponseData {
-    // Echo the incoming assertion token as access token so NAVident survives OBO flow in tests.
+    // Echo the incoming "assertion" token (see getOnBehalfOfToken() in  AzureAdClient) as access
+    // token. This makes it so that the navIdent claim in the token that an endpoint was called
+    // with in the API tests survives OBO flow and can be read out again by TilgangskontrollMock.
     val assertionToken = (request.body as? FormDataContent)?.formData?.get("assertion")
     return respond(
         AzureAdTokenResponse(

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
@@ -11,7 +11,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
         addHandler { request ->
             val requestUrl = request.url.encodedPath
             when {
-                requestUrl == "/${environment.azure.openidConfigTokenEndpoint}" -> azureAdMockResponse()
+                requestUrl == "/${environment.azure.openidConfigTokenEndpoint}" -> azureAdMockResponse(request)
                 requestUrl.startsWith("/${environment.clients.istilgangskontroll.baseUrl}") -> tilgangskontrollResponse(
                     request
                 )

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/MockHttpClient.kt
@@ -12,6 +12,7 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
             val requestUrl = request.url.encodedPath
             when {
                 requestUrl == "/${environment.azure.openidConfigTokenEndpoint}" -> azureAdMockResponse(request)
+
                 requestUrl.startsWith("/${environment.clients.istilgangskontroll.baseUrl}") -> tilgangskontrollResponse(
                     request
                 )
@@ -21,7 +22,9 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
                 )
 
                 requestUrl.startsWith("/${environment.clients.pdl.baseUrl}") -> pdlMockResponse(request)
+
                 requestUrl.startsWith("/${environment.clients.dokarkiv.baseUrl}") -> dokarkivMockResponse(request)
+
                 else -> error("Unhandled ${request.url.encodedPath}")
             }
         }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/TilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/TilgangskontrollMock.kt
@@ -1,22 +1,35 @@
 package no.nav.syfo.testhelper.mock
 
+import com.auth0.jwt.JWT
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
+import io.ktor.http.HttpHeaders
 import kotlinx.coroutines.runBlocking
 import no.nav.syfo.infrastructure.client.veiledertilgang.Tilgang
 import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.testhelper.UserConstants.PERSONIDENT_VEILEDER_NO_ACCESS
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_WITH_LESETILGANG
+import no.nav.syfo.util.JWT_CLAIM_NAVIDENT
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
+
+private val navIdentsWithLeseTilgangOnly = setOf(VEILEDER_IDENT_WITH_LESETILGANG)
+
+// Decode caller NAVident from bearer token so the mock can enforce user-level write access.
+private fun HttpRequestData.navIdent(): String? =
+    headers[HttpHeaders.Authorization]
+        ?.removePrefix("Bearer ")
+        ?.let { token ->
+            runCatching { JWT.decode(token).claims[JWT_CLAIM_NAVIDENT]?.asString() }.getOrNull()
+        }
 
 fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
     val requestUrl = request.url.encodedPath
 
     return when {
         requestUrl.endsWith(VeilederTilgangskontrollClient.TILGANGSKONTROLL_PERSON_PATH) -> {
-            when (request.headers[NAV_PERSONIDENT_HEADER]) {
-                PERSONIDENT_VEILEDER_NO_ACCESS.value -> respond(Tilgang(erGodkjent = false))
-                else -> respond(Tilgang(erGodkjent = true))
-            }
+            val erGodkjent = request.headers[NAV_PERSONIDENT_HEADER] != PERSONIDENT_VEILEDER_NO_ACCESS.value
+            val fullTilgang = request.navIdent() !in navIdentsWithLeseTilgangOnly
+            respond(Tilgang(erGodkjent = erGodkjent, fullTilgang = fullTilgang))
         }
         requestUrl.endsWith(VeilederTilgangskontrollClient.TILGANGSKONTROLL_BRUKERE_PATH) -> {
             val body = runBlocking<List<String>> { request.receiveBody() }.toMutableList()

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/TilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/TilgangskontrollMock.kt
@@ -14,7 +14,8 @@ import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 
 private val navIdentsWithLeseTilgangOnly = setOf(VEILEDER_IDENT_WITH_LESETILGANG)
 
-// Decode caller NAVident from bearer token so the mock can enforce user-level write access.
+// Decode caller navIdent claim from token so this mock can enforce write access for specific
+// test veileder idents (see src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt).
 private fun HttpRequestData.navIdent(): String? =
     headers[HttpHeaders.Authorization]
         ?.removePrefix("Bearer ")

--- a/src/test/kotlin/no/nav/syfo/util/PipelineUtilTest.kt
+++ b/src/test/kotlin/no/nav/syfo/util/PipelineUtilTest.kt
@@ -1,0 +1,191 @@
+package no.nav.syfo.util
+
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.server.routing.RoutingCall
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.RoutingRequest
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.api.exception.ForbiddenAccessVeilederException
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.client.veiledertilgang.VeilederTilgangskontrollClient
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PipelineUtilTest {
+    private val action = "read aktivitetskrav"
+    private val callId = "123"
+    private val personIdent = PersonIdent("12345678910")
+    private val token = "token"
+
+    private val veilederTilgangskontrollClient = mockk<VeilederTilgangskontrollClient>()
+
+    @Test
+    fun `calls hasAccess and executes block when read access is granted`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+        var blockCalled = false
+
+        coEvery {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        } returns true
+
+        runBlocking {
+            routingContext.checkVeilederTilgang(
+                action = action,
+                veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+            ) {
+                blockCalled = true
+            }
+        }
+
+        assertTrue(blockCalled)
+        coVerify(exactly = 1) {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasWriteAccess(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `calls hasWriteAccess and executes block when write access is granted`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+        var blockCalled = false
+
+        coEvery {
+            veilederTilgangskontrollClient.hasWriteAccess(callId, personIdent, token)
+        } returns true
+
+        runBlocking {
+            routingContext.checkVeilederTilgang(
+                action = action,
+                veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                requiresWriteAccess = true,
+            ) {
+                blockCalled = true
+            }
+        }
+
+        assertTrue(blockCalled)
+        coVerify(exactly = 1) {
+            veilederTilgangskontrollClient.hasWriteAccess(callId, personIdent, token)
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasAccess(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `throws forbidden and does not execute block when read access is denied`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+        var blockCalled = false
+
+        coEvery {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        } returns false
+
+        assertThrows(ForbiddenAccessVeilederException::class.java) {
+            runBlocking {
+                routingContext.checkVeilederTilgang(
+                    action = action,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                ) {
+                    blockCalled = true
+                }
+            }
+        }
+
+        assertFalse(blockCalled)
+        coVerify(exactly = 1) {
+            veilederTilgangskontrollClient.hasAccess(callId, personIdent, token)
+        }
+    }
+
+    @Test
+    fun `throws illegal argument when authorization header is missing`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(NAV_PERSONIDENT_HEADER, personIdent.value)
+            }
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                routingContext.checkVeilederTilgang(
+                    action = action,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                ) {}
+            }
+        }
+
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasAccess(any(), any(), any())
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasWriteAccess(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `throws illegal argument when personident header is missing`() {
+        val routingContext = routingContextWithHeaders(
+            headers = Headers.build {
+                append(NAV_CALL_ID_HEADER, callId)
+                append(HttpHeaders.Authorization, bearerHeader(token))
+            }
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                routingContext.checkVeilederTilgang(
+                    action = action,
+                    veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+                ) {}
+            }
+        }
+
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasAccess(any(), any(), any())
+        }
+        coVerify(exactly = 0) {
+            veilederTilgangskontrollClient.hasWriteAccess(any(), any(), any())
+        }
+    }
+
+    private fun routingContextWithHeaders(headers: Headers): RoutingContext {
+        val routingRequest = mockk<RoutingRequest>()
+        every { routingRequest.headers } returns headers
+
+        val routingCall = mockk<RoutingCall>()
+        every { routingCall.request } returns routingRequest
+
+        val routingContext = mockk<RoutingContext>()
+        every { routingContext.call } returns routingCall
+        return routingContext
+    }
+}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Sjekker at bruker har "full tilgang" i følge `istilgangskontroll` når brukeren prøver å utføre en "skriveoperasjon", altså en handling som endrer noe.

Se også tilsvarende endring i [denne draft PRen i isoppfolgingsplan](https://github.com/navikt/isoppfolgingsplan/pull/105) der det ikke er lagt til eller endret tester ennå. Så det kan være lettere å se selve endringen der.

Foreløpig har en bruker full tilgang i følge `istilgangskontroll` også når brukeren har dagens "legacy-tilgang", se https://github.com/navikt/istilgangskontroll/blob/e779608cc25df1b7ae49a996c0feb45f19e2afbe/src/main/kotlin/no/nav/syfo/domain/Veileder.kt#L31-L30.

`VeilederTilgangskontrollClient` hadde fra før en `hasAccess()`-metode som kaller istilgangskontroll og sjekker om bruker har tilgang til en person. Denne er nå skrevet litt om til en`private getTilgang()`-metode som returnerer tilgangen fra istilgangskontroll. To funksjoner, `hasAccess()` (gir lik oppførsel som tidligere funskjon med  samme navn) og `hasWriteAccess()` er lagt til som kaller `getTilgang()` for å få Tilgang-DTOen og returnerer en Boolean basert på innholdet i Tilgang-DTOen.

`checkVeilederTilgang()` i `PipelineUtil.kt` er endret til å ta inn en valgfri parameter `requiresWriteAccess`. Hvis den er true så sjekkes det om personen har skrivetilgang ved bruk av `hasWriteAccess`, ellers brukes `hasAccess()` som før. Se oppdaterte callsites i `AktivitetskravApi.kt`.

Eksisterende API-tester `AktivitetskravApiTest.kt`, `AktivitetskravApiVurderTest.kt` og `AktivitetskravApiForhandsvarselTest.kt` og mock-hjelpere er endret for å ta hensyn til endret tilgangskontroll. Et nytt konsept som er innført der er at ulike Nav-identer / veileder-identer har ulik fagtilgang - det vil si det er en Nav-ident som kun har lesetilgang. I mock-hjelperen som avgjør hvilken tilgangs-DTO som returneres fra istilgangskontroll så dekodes mock-veilederens bruker-token for å lese ut den opprinnelige identen og bruke det for den avgjørelsen.

De nye testene for `VeilederTilgangskontrollClient` og `PipelineUtil` er hovedsakelig KI-generert. Jeg har sett gjennom og vurdert dem nokså nøye og gjort noen justeringer. Kanskje kan antallet tester reduseres noe.

Noe som kan vurderes er navngivingen av tilgangskonsepter, slik som "write access". Her er jeg litt usikker. Sånn som dette blir det foreløpig slik at "du har writeAccess ifølge isaktivitetskrav hvis du har full tilgang ifølge `istilgangskontroll`". En grunn til at jeg skrev det sånn nå foreløpig var at det var `hasAccess` der fra før (som sjekker om bruker har tilgang til en bestemt person, og har minst lese-fagtilgangen). Vi kan kanskje ta en større "naming-pass" senere.