### PR TITLE
Simplify VeilederTilgangskontrollClientTest

### DIFF
--- a/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
@@ -38,8 +38,8 @@ class VeilederTilgangskontrollClientTest {
     private val oboToken = "obo-token"
     private val callId = "call-id"
     private val personident = PersonIdent("12345678910")
-    private val azureAdClient = mockk<AzureAdClient>()
     private val clientEnvironment = testEnvironment().clients.istilgangskontroll
+    private val azureAdClient = mockk<AzureAdClient>()
 
     @BeforeEach
     fun setup() {
@@ -93,61 +93,47 @@ class VeilederTilgangskontrollClientTest {
     }
 
     @Test
-    fun `hasAccess returns false when tilgang is not approved`() {
-        val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
-
-        runBlocking {
-            assertFalse(client.hasAccess(callId, personident, token))
-        }
-    }
-
-    @Test
-    fun `hasAccess returns false on forbidden response`() {
-        val client = createMockClientForResponse(status = HttpStatusCode.Forbidden)
-
-        runBlocking {
-            assertFalse(client.hasAccess(callId, personident, token))
-        }
-    }
-
-    @Test
-    fun `hasWriteAccess returns true when tilgang to person is approved and user has fullTilgang`() {
+    fun `hasAccess and hasWriteAccess returns true when tilgang to person is approved and user has fullTilgang`() {
         val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = true))
 
         runBlocking {
+            assertTrue(client.hasAccess(callId, personident, token))
             assertTrue(client.hasWriteAccess(callId, personident, token))
         }
     }
 
     @Test
-    fun `hasWriteAccess returns false when tilgang to person is approved but user does not have fullTilgang`() {
+    fun `hasAccess returns true and hasWriteAccess returns false when tilgang to person is approved but user does not have fullTilgang`() {
         val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = false))
 
         runBlocking {
+            assertTrue(client.hasAccess(callId, personident, token))
             assertFalse(client.hasWriteAccess(callId, personident, token))
         }
     }
 
     @Test
-    fun `hasWriteAccess returns false when tilgang to person is not approved`() {
+    fun `hasAccess and hasWriteAccess returns false when tilgang is not approved`() {
         val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
 
         runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
             assertFalse(client.hasWriteAccess(callId, personident, token))
         }
     }
 
     @Test
-    fun `hasWriteAccess returns false on unexpected response`() {
+    fun `hasAccess and hasWriteAccess returns false on unexpected response`() {
         val client = createMockClientForResponse(status = HttpStatusCode.InternalServerError)
 
         runBlocking {
+            assertFalse(client.hasAccess(callId, personident, token))
             assertFalse(client.hasWriteAccess(callId, personident, token))
         }
     }
 
     @Test
-    fun `hasAccess throws when obo token request fails`() {
+    fun `hasAccess and hasWriteAccess throws when obo token request fails`() {
         coEvery {
             azureAdClient.getOnBehalfOfToken(any(), any())
         } returns null
@@ -157,6 +143,11 @@ class VeilederTilgangskontrollClientTest {
         assertThrows(RuntimeException::class.java) {
             runBlocking {
                 client.hasAccess(callId, personident, token)
+            }
+        }
+        assertThrows(RuntimeException::class.java) {
+            runBlocking {
+                client.hasWriteAccess(callId, personident, token)
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/veiledertilgang/VeilederTilgangskontrollClientTest.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respondError
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
@@ -19,10 +20,12 @@ import no.nav.syfo.testhelper.testEnvironment
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.bearerHeader
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
@@ -34,12 +37,27 @@ class VeilederTilgangskontrollClientTest {
     private val token = "token"
     private val oboToken = "obo-token"
     private val callId = "call-id"
-    private val personIdent = PersonIdent("12345678910")
+    private val personident = PersonIdent("12345678910")
+    private val azureAdClient = mockk<AzureAdClient>()
     private val clientEnvironment = testEnvironment().clients.istilgangskontroll
+
+    @BeforeEach
+    fun setup() {
+        coEvery {
+            azureAdClient.getOnBehalfOfToken(any(), any())
+        } returns AzureAdToken(
+            accessToken = oboToken,
+            expires = LocalDateTime.now().plusHours(1),
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
 
     @Test
     fun `hasAccess returns true when tilgang is approved and sends expected headers to istilgangskontroll`() {
-        val azureAdClient = mockAzureAdClientGetOBOToken()
         lateinit var authorizationHeader: String
         lateinit var personidentHeader: String
         lateinit var callIdHeader: String
@@ -66,11 +84,11 @@ class VeilederTilgangskontrollClientTest {
         )
 
         runBlocking {
-            assertTrue(client.hasAccess(callId, personIdent, token))
+            assertTrue(client.hasAccess(callId, personident, token))
         }
 
         assertEquals(bearerHeader(oboToken), authorizationHeader)
-        assertEquals(personIdent.value, personidentHeader)
+        assertEquals(personident.value, personidentHeader)
         assertEquals(callId, callIdHeader)
     }
 
@@ -79,7 +97,7 @@ class VeilederTilgangskontrollClientTest {
         val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
 
         runBlocking {
-            assertFalse(client.hasAccess(callId, personIdent, token))
+            assertFalse(client.hasAccess(callId, personident, token))
         }
     }
 
@@ -88,7 +106,7 @@ class VeilederTilgangskontrollClientTest {
         val client = createMockClientForResponse(status = HttpStatusCode.Forbidden)
 
         runBlocking {
-            assertFalse(client.hasAccess(callId, personIdent, token))
+            assertFalse(client.hasAccess(callId, personident, token))
         }
     }
 
@@ -97,7 +115,7 @@ class VeilederTilgangskontrollClientTest {
         val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = true))
 
         runBlocking {
-            assertTrue(client.hasWriteAccess(callId, personIdent, token))
+            assertTrue(client.hasWriteAccess(callId, personident, token))
         }
     }
 
@@ -106,7 +124,7 @@ class VeilederTilgangskontrollClientTest {
         val client = createMockClientForResponse(Tilgang(erGodkjent = true, fullTilgang = false))
 
         runBlocking {
-            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
         }
     }
 
@@ -115,7 +133,7 @@ class VeilederTilgangskontrollClientTest {
         val client = createMockClientForResponse(Tilgang(erGodkjent = false, fullTilgang = true))
 
         runBlocking {
-            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
         }
     }
 
@@ -124,33 +142,21 @@ class VeilederTilgangskontrollClientTest {
         val client = createMockClientForResponse(status = HttpStatusCode.InternalServerError)
 
         runBlocking {
-            assertFalse(client.hasWriteAccess(callId, personIdent, token))
+            assertFalse(client.hasWriteAccess(callId, personident, token))
         }
     }
 
     @Test
     fun `hasAccess throws when obo token request fails`() {
-        val azureAdClient = mockk<AzureAdClient>()
         coEvery {
-            azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)
+            azureAdClient.getOnBehalfOfToken(any(), any())
         } returns null
 
-        val httpClient = HttpClient(MockEngine) {
-            commonConfig()
-            engine {
-                addHandler { respond(Tilgang(erGodkjent = true)) }
-            }
-        }
-
-        val client = VeilederTilgangskontrollClient(
-            azureAdClient = azureAdClient,
-            clientEnvironment = clientEnvironment,
-            httpClient = httpClient,
-        )
+        val client = createMockClientForResponse()
 
         assertThrows(RuntimeException::class.java) {
             runBlocking {
-                client.hasAccess(callId, personIdent, token)
+                client.hasAccess(callId, personident, token)
             }
         }
     }
@@ -162,7 +168,6 @@ class VeilederTilgangskontrollClientTest {
         tilgang: Tilgang = Tilgang(erGodkjent = true),
         status: HttpStatusCode = HttpStatusCode.OK,
     ): VeilederTilgangskontrollClient {
-        val azureAdClient = mockAzureAdClientGetOBOToken()
         val httpClient = HttpClient(MockEngine) {
             commonConfig()
             engine {
@@ -181,16 +186,5 @@ class VeilederTilgangskontrollClientTest {
             clientEnvironment = clientEnvironment,
             httpClient = httpClient,
         )
-    }
-
-    private fun mockAzureAdClientGetOBOToken(): AzureAdClient {
-        val azureAdClient = mockk<AzureAdClient>()
-        coEvery {
-            azureAdClient.getOnBehalfOfToken(scopeClientId = clientEnvironment.clientId, token = token)
-        } returns AzureAdToken(
-            accessToken = oboToken,
-            expires = LocalDateTime.now().plusHours(1),
-        )
-        return azureAdClient
     }
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Simplify VeilederTilgangskontrollClientTest with setup and teardown and reusing mocks.

Samme som @eirikdahlen gjorde i isbehandlerdialog. Men fortsatt med "kontrakt-test" som tester at istilgangskontroll-APIet blir kalt med headere ut fra konstruktør-parametre.