### PR TITLE
Replace embedded-redis with Testcontainers for arm64 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ val nimbusJoseJwtVersion = "10.9"
 val postgresVersion = "42.7.10"
 val postgresEmbeddedVersion = "2.2.2"
 val postgresRuntimeVersion = "17.9.0"
-val redisEmbeddedVersion = "0.7.3"
+val testContainersVersion = "1.21.0"
 
 plugins {
     kotlin("jvm") version "2.3.10"
@@ -69,7 +69,7 @@ dependencies {
 
     // Cache
     implementation("redis.clients:jedis:$jedisVersion")
-    testImplementation("it.ozimov:embedded-redis:$redisEmbeddedVersion")
+    testImplementation("org.testcontainers:testcontainers:$testContainersVersion")
 
     // Kafka
     val excludeLog4j = fun ExternalModuleDependency.() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ val nimbusJoseJwtVersion = "10.9"
 val postgresVersion = "42.7.10"
 val postgresEmbeddedVersion = "2.2.2"
 val postgresRuntimeVersion = "17.9.0"
-val testContainersVersion = "1.21.0"
+val testContainersVersion = "2.0.5"
 
 plugins {
     kotlin("jvm") version "2.3.10"

--- a/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/ExternalMockEnvironment.kt
@@ -24,6 +24,7 @@ class ExternalMockEnvironment private constructor() {
     val mockHttpClient = mockHttpClient(environment = environment)
 
     val redisServer = testValkeyServer(valkeyConfig = environment.valkeyConfig)
+        .also { it.start() }
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
     val azureAdClient = AzureAdClient(
         azureEnvironment = environment.azure,
@@ -37,10 +38,10 @@ class ExternalMockEnvironment private constructor() {
         azureAdClient = azureAdClient,
         pdlEnvironment = environment.clients.pdl,
         httpClient = mockHttpClient,
-        cache = testValkeyCache(valkeyConfig = environment.valkeyConfig),
+        cache = testValkeyCache(container = redisServer, valkeyConfig = environment.valkeyConfig),
     )
 
     companion object {
-        val instance: ExternalMockEnvironment = ExternalMockEnvironment().also { it.redisServer.start() }
+        val instance: ExternalMockEnvironment = ExternalMockEnvironment()
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestValkey.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestValkey.kt
@@ -2,24 +2,24 @@ package no.nav.syfo.testhelper
 
 import no.nav.syfo.api.cache.ValkeyConfig
 import no.nav.syfo.api.cache.ValkeyStore
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.JedisPoolConfig
 import redis.clients.jedis.Protocol
-import redis.embedded.RedisServer
 
 fun testValkeyServer(
     valkeyConfig: ValkeyConfig,
-): RedisServer = RedisServer.builder()
-    .port(valkeyConfig.port)
-    .setting("requirepass ${valkeyConfig.valkeyPassword}")
-    .setting("maxmemory 1024M")
-    .build()
+): GenericContainer<*> = GenericContainer<Nothing>(DockerImageName.parse("redis:7-alpine")).apply {
+    withExposedPorts(6379)
+    withCommand("redis-server", "--requirepass", valkeyConfig.valkeyPassword, "--maxmemory", "1024M")
+}
 
-fun testValkeyCache(valkeyConfig: ValkeyConfig): ValkeyStore = ValkeyStore(
+fun testValkeyCache(container: GenericContainer<*>, valkeyConfig: ValkeyConfig): ValkeyStore = ValkeyStore(
     JedisPool(
         JedisPoolConfig(),
-        valkeyConfig.host,
-        valkeyConfig.port,
+        container.host,
+        container.getMappedPort(6379),
         Protocol.DEFAULT_TIMEOUT,
         valkeyConfig.valkeyPassword
     )


### PR DESCRIPTION
## Why

The `it.ozimov:embedded-redis` library bundles a pre-compiled x86/x86_64 Redis binary that it extracts and runs at test time. It seems on Apple Silicon Macs, this binary cannot execute — causing the test suite to fail locally on any modern Mac.

## What changed

- Replaced `it.ozimov:embedded-redis` with `org.testcontainers:testcontainers`
- `TestValkey` now starts a `redis:7-alpine` Docker container via Testcontainers instead of an in-process embedded server
- The container's dynamically assigned host and port are passed to the Jedis connection pool, replacing the previously hardcoded config values

## Trade-off

Tests now require Docker to be running locally. This is a standard requirement and a reasonable trade-off for cross-platform compatibility.